### PR TITLE
Python accessible search

### DIFF
--- a/hera_librarian/__init__.py
+++ b/hera_librarian/__init__.py
@@ -183,7 +183,6 @@ class LibrarianClient (object):
         # die or whatever.
 
         staged_path = os.path.join(staging_dir, os.path.basename(dest_store_path))
-
         store.copy_to_store(local_path, staged_path)
 
         # If we made it here, though, the upload succeeded and we can tell

--- a/hera_librarian/__init__.py
+++ b/hera_librarian/__init__.py
@@ -269,9 +269,22 @@ class LibrarianClient (object):
                                   search=search,
                                   output_format='session-listing-json',
                                   )
-
-    def search_json(self, search,output_format):
-        return self._do_http_post('search-json',
+                                  
+    def search_files(self, search):
+        return self._do_http_post('search',
                                   search=search,
-                                  output_format=output_format,
+                                  output_format='file-listing-json',
+                                  )
+                                  
+    def search_instances(self, search):
+        return self._do_http_post('search',
+                                  search=search,
+                                  output_format='instance-listing-json',
                                   )                                  
+                                  
+    def search_observations(self, search):
+        return self._do_http_post('search',
+                                  search=search,
+                                  output_format='obs-listing-json',
+                                  )
+

--- a/hera_librarian/__init__.py
+++ b/hera_librarian/__init__.py
@@ -183,6 +183,7 @@ class LibrarianClient (object):
         # die or whatever.
 
         staged_path = os.path.join(staging_dir, os.path.basename(dest_store_path))
+
         store.copy_to_store(local_path, staged_path)
 
         # If we made it here, though, the upload succeeded and we can tell
@@ -269,3 +270,9 @@ class LibrarianClient (object):
                                   search=search,
                                   output_format='session-listing-json',
                                   )
+
+    def search_json(self, search,output_format):
+        return self._do_http_post('search-json',
+                                  search=search,
+                                  output_format=output_format,
+                                  )                                  

--- a/hera_librarian/store.py
+++ b/hera_librarian/store.py
@@ -134,7 +134,7 @@ class Store (object):
         argv = [
             'rsync',
             '-aP',
-            '-e', 'ssh -c arcfour256 -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no',
+            '-e', 'ssh -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no',
             local_path + local_suffix, '%s:%s' % (self.ssh_host, self._path(store_path))
         ]
         success = False

--- a/server/librarian_server/file.py
+++ b/server/librarian_server/file.py
@@ -452,6 +452,14 @@ class FileInstance (db.Model):
     def deletion_policy_text(self):
         return DeletionPolicy.textualize(self.deletion_policy)
 
+    def to_dict(self):
+        return dict(
+            store=self.store,
+            parent_dirs=self.parent_dirs,
+            name=self.name,
+            deletion_policy=self.deletion_policy,
+            full_path_on_store= os.path.join(self.store_object.path_prefix, self.parent_dirs, self.name)
+        )
 
 class FileEvent (db.Model):
     """A FileEvent is a something that happens to a File on this Librarian.

--- a/server/librarian_server/file.py
+++ b/server/librarian_server/file.py
@@ -458,7 +458,7 @@ class FileInstance (db.Model):
             parent_dirs=self.parent_dirs,
             name=self.name,
             deletion_policy=self.deletion_policy,
-            full_path_on_store= os.path.join(self.store_object.path_prefix, self.parent_dirs, self.name)
+            full_path_on_store=self.full_path_on_store()
         )
 
 class FileEvent (db.Model):

--- a/server/librarian_server/search.py
+++ b/server/librarian_server/search.py
@@ -476,9 +476,9 @@ def compile_search(search_string, query_type='files'):
         # The following syntax gives us a LEFT OUTER JOIN which is what we want to
         # get (at most) one instance for each File of interest.
         return (db.session.query(FileInstance, File, Store)
-            .join(Store)
-            .join(File, isouter=True)
-            .filter(the_file_search_compiler.compile(search)))
+                .join(Store)
+                .join(File, isouter=True)
+                .filter(the_file_search_compiler.compile(search)))
     elif query_type == 'instances-paths':        
         return FileInstance.query.filter(the_file_search_compiler.compile(search))
     else:

--- a/server/librarian_server/search.py
+++ b/server/librarian_server/search.py
@@ -473,10 +473,13 @@ def compile_search(search_string, query_type='files'):
     elif query_type == 'sessions':
         return ObservingSession.query.filter(the_session_search_compiler.compile(search))
     elif query_type == 'instances-stores':
-        #return File.query.filter(the_file_search_compiler.compile(search))
         # The following syntax gives us a LEFT OUTER JOIN which is what we want to
         # get (at most) one instance for each File of interest.
-        #return db.session.query(FileInstance).filter(the_file_search_compiler.compile(search))
+        return (db.session.query(FileInstance, File, Store)
+            .join(Store)
+            .join(File, isouter=True)
+            .filter(the_file_search_compiler.compile(search)))
+    elif query_type == 'instances-paths':        
         return FileInstance.query.filter(the_file_search_compiler.compile(search))
     else:
         raise ServerError('unhandled query_type %r', query_type)
@@ -1138,7 +1141,7 @@ def execute_search_api(args, sourcename=None):
     elif output_format == file_listing_json_format:
         query_type = 'files'
     elif output_format == instance_listing_json_format:
-        query_type = 'instances-stores'
+        query_type = 'instances-paths'
     elif output_format == obs_listing_json_format:
         query_typ = 'obs'
     else:

--- a/server/librarian_server/search.py
+++ b/server/librarian_server/search.py
@@ -1174,5 +1174,3 @@ def execute_search_api(args, sourcename=None):
         )
     else:
         raise ServerError('internal logic failure mishandled output format')
-        
-


### PR DESCRIPTION
Based on the web search accepts json input but returns a python list
of files or paths which match the search criteria

This is working on my local librarian set-up as far as my needs go, and seems to avoid the rest of the server.
Example implementation is thus:

```python
import hera_librarian
client = hera_librarian.LibrarianClient("local")
result = client.search_json(search='{ "name-matches": "zen.2457644.%.xx.HH.uvc" }',output_format='Raw text with file names')

print result["filelist"]
```


Let me know what you think

