### PR TITLE
Upgrade to python3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       python_version:
         type: string
     docker:
-      - image: continuumio/miniconda:latest
+      - image: continuumio/miniconda3:latest
       - image: circleci/postgres:11
         environment:
           POSTGRES_USER: root

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,5 +60,5 @@ workflows:
   build_and_test:
     jobs:
       - librarian:
-          name: librarian_2.7
-          python_version: "2.7"
+          name: librarian_3.7
+          python_version: "3.7"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version *next* (not yet released)
 
+
+# Version 1.0.0 (2019 Sep 19)
+
+- Convert codebase from python2 to python3.
 - Move scripts to `cli.py` module and replace with single command.
 - Reorganize repo structure.
 - Add tests and CI support.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -6,7 +6,7 @@
 migration stuff.
 
 """
-from __future__ import with_statement
+
 
 # A hack so that we can get the librarian_server module.
 import sys

--- a/alembic/versions/71df5b41ae41_initial_schema.py
+++ b/alembic/versions/71df5b41ae41_initial_schema.py
@@ -22,8 +22,8 @@ def upgrade():
     # This is the schema used by the first Librarian deployments.
     op.create_table('observing_session',
                     sa.Column('id', sa.BigInteger(), nullable=False),
-                    sa.Column('start_time_jd', sa.Float(precision=u'53'), nullable=False),
-                    sa.Column('stop_time_jd', sa.Float(precision=u'53'), nullable=False),
+                    sa.Column('start_time_jd', sa.Float(precision='53'), nullable=False),
+                    sa.Column('stop_time_jd', sa.Float(precision='53'), nullable=False),
                     sa.PrimaryKeyConstraint('id')
                     )
 
@@ -49,11 +49,11 @@ def upgrade():
 
     op.create_table('observation',
                     sa.Column('obsid', sa.BigInteger(), nullable=False),
-                    sa.Column('start_time_jd', sa.Float(precision=u'53'), nullable=False),
-                    sa.Column('stop_time_jd', sa.Float(precision=u'53'), nullable=True),
-                    sa.Column('start_lst_hr', sa.Float(precision=u'53'), nullable=True),
+                    sa.Column('start_time_jd', sa.Float(precision='53'), nullable=False),
+                    sa.Column('stop_time_jd', sa.Float(precision='53'), nullable=True),
+                    sa.Column('start_lst_hr', sa.Float(precision='53'), nullable=True),
                     sa.Column('session_id', sa.BigInteger(), nullable=True),
-                    sa.ForeignKeyConstraint(['session_id'], [u'observing_session.id'], ),
+                    sa.ForeignKeyConstraint(['session_id'], ['observing_session.id'], ),
                     sa.PrimaryKeyConstraint('obsid')
                     )
 
@@ -65,7 +65,7 @@ def upgrade():
                     sa.Column('size', sa.BigInteger(), nullable=False),
                     sa.Column('md5', sa.String(length=32), nullable=False),
                     sa.Column('source', sa.String(length=64), nullable=False),
-                    sa.ForeignKeyConstraint(['obsid'], [u'observation.obsid'], ),
+                    sa.ForeignKeyConstraint(['obsid'], ['observation.obsid'], ),
                     sa.PrimaryKeyConstraint('name')
                     )
 
@@ -75,7 +75,7 @@ def upgrade():
                     sa.Column('time', sa.DateTime(), nullable=False),
                     sa.Column('type', sa.String(length=64), nullable=True),
                     sa.Column('payload', sa.Text(), nullable=True),
-                    sa.ForeignKeyConstraint(['name'], [u'file.name'], ),
+                    sa.ForeignKeyConstraint(['name'], ['file.name'], ),
                     sa.PrimaryKeyConstraint('id')
                     )
 
@@ -83,8 +83,8 @@ def upgrade():
                     sa.Column('store', sa.BigInteger(), nullable=False),
                     sa.Column('parent_dirs', sa.String(length=128), nullable=False),
                     sa.Column('name', sa.String(length=256), nullable=False),
-                    sa.ForeignKeyConstraint(['name'], [u'file.name'], ),
-                    sa.ForeignKeyConstraint(['store'], [u'store.id'], ),
+                    sa.ForeignKeyConstraint(['name'], ['file.name'], ),
+                    sa.ForeignKeyConstraint(['store'], ['store.id'], ),
                     sa.PrimaryKeyConstraint('store', 'parent_dirs', 'name')
                     )
 

--- a/hera_librarian/__init__.py
+++ b/hera_librarian/__init__.py
@@ -79,7 +79,7 @@ class LibrarianClient (object):
 
         """
         kwargs['authenticator'] = self.config['authenticator']
-        for k in list(kwargs.keys()):
+        for k in kwargs.keys():
             if kwargs[k] is None:
                 kwargs.pop(k)
         req_json = json.dumps(kwargs)

--- a/hera_librarian/__init__.py
+++ b/hera_librarian/__init__.py
@@ -2,11 +2,11 @@
 # Copyright 2016 the HERA Team.
 # Licensed under the BSD License.
 
-from __future__ import absolute_import, division, print_function
+
 
 import json
 import os.path
-import urllib
+import urllib.request, urllib.parse, urllib.error
 
 __all__ = str('''
 NoSuchConnectionError
@@ -15,7 +15,7 @@ LibrarianClient
 ''').split()
 
 
-__version__ = "0.1.7a0"
+__version__ = "1.0.0"
 
 
 class NoSuchConnectionError (Exception):
@@ -79,14 +79,14 @@ class LibrarianClient (object):
 
         """
         kwargs['authenticator'] = self.config['authenticator']
-        for k in kwargs.keys():
+        for k in list(kwargs.keys()):
             if kwargs[k] is None:
                 kwargs.pop(k)
         req_json = json.dumps(kwargs)
 
-        params = urllib.urlencode({'request': req_json})
+        params = urllib.parse.urlencode({'request': req_json})
         url = self.config['url'] + 'api/' + operation
-        f = urllib.urlopen(url, params)
+        f = urllib.request.urlopen(url, params)
         reply = f.read()
         try:
             reply_json = json.loads(reply)

--- a/hera_librarian/base_store.py
+++ b/hera_librarian/base_store.py
@@ -10,7 +10,7 @@ that.
 
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 __all__ = str('''
 BaseStore
@@ -79,9 +79,9 @@ class BaseStore (object):
 
         if proc.returncode != 0:
             raise RPCError(argv, 'exit code %d; stdout:\n\n%r\n\nstderr:\n\n%r'
-                           % (proc.returncode, stdout, stderr))
+                           % (proc.returncode, stdout.decode("utf-8"), stderr.decode("utf-8")))
 
-        return stdout
+        return stdout.decode("utf-8")
 
     def _stream_path(self, store_path):
         """Return a subprocess.Popen instance that streams file contents on its
@@ -139,7 +139,7 @@ class BaseStore (object):
         ]
         success = False
 
-        for i in xrange(NUM_RSYNC_TRIES):
+        for i in range(NUM_RSYNC_TRIES):
             proc = subprocess.Popen(argv, shell=False, stdout=subprocess.PIPE,
                                     stderr=subprocess.STDOUT)
             output = proc.communicate()[0]

--- a/hera_librarian/base_store.py
+++ b/hera_librarian/base_store.py
@@ -81,7 +81,7 @@ class BaseStore (object):
             raise RPCError(argv, 'exit code %d; stdout:\n\n%r\n\nstderr:\n\n%r'
                            % (proc.returncode, stdout.decode("utf-8"), stderr.decode("utf-8")))
 
-        return stdout.decode("utf-8")
+        return stdout
 
     def _stream_path(self, store_path):
         """Return a subprocess.Popen instance that streams file contents on its
@@ -235,7 +235,8 @@ class BaseStore (object):
         path".
 
         """
-        output = self._ssh_slurp('mktemp -d -p %s %s.XXXXXX' % (self.path_prefix, key))
+        # we need to convert the output of _ssh_slurp -- a path in bytes -- to a string
+        output = self._ssh_slurp('mktemp -d -p %s %s.XXXXXX' % (self.path_prefix, key)).decode("utf-8")
         fullpath = output.splitlines()[-1].strip()
 
         if not fullpath.startswith(self.path_prefix):

--- a/hera_librarian/cli.py
+++ b/hera_librarian/cli.py
@@ -6,7 +6,7 @@
 
 """
 
-from __future__ import absolute_import, division, print_function
+
 
 
 import argparse
@@ -91,7 +91,7 @@ def print_table(dict_list, col_list=None, col_names=None):
     for item in dict_list:
         myList.append([str(item[col] or '') for col in col_list])
     # figure out the maximum size for each column
-    colSize = [max(map(len, col)) for col in zip(*myList)]
+    colSize = [max(list(map(len, col))) for col in zip(*myList)]
     formatStr = ' | '.join(["{{:<{}}}".format(i) for i in colSize])
     myList.insert(1, ['-' * i for i in colSize])  # Seperating line
     for item in myList:
@@ -618,7 +618,7 @@ def delete_files(args):
     n_deleted = 0
     n_error = 0
 
-    for fname, stats in sorted(allstats.iteritems(), key=lambda t: t[0]):
+    for fname, stats in sorted(iter(allstats.items()), key=lambda t: t[0]):
         nd = stats.get("n_deleted", 0)
         nk = stats.get("n_kept", 0)
         ne = stats.get("n_error", 0)

--- a/hera_librarian/tests/test_base_store.py
+++ b/hera_librarian/tests/test_base_store.py
@@ -40,7 +40,7 @@ def test_path(local_store):
 
 def test_ssh_slurp(local_store):
     # test simple command
-    assert local_store[0]._ssh_slurp("echo hello world") == "hello world\n"
+    assert local_store[0]._ssh_slurp("echo hello world").decode("utf-8") == "hello world\n"
 
     # try a bogus command
     with pytest.raises(RPCError):
@@ -63,7 +63,7 @@ def test_copy_to_store(tmpdir, local_store):
 
     # check that it exists
     dirpath = os.path.join(local_store[1], "test_directory")
-    assert local_store[0]._ssh_slurp("ls {}".format(dirpath)) == "my_file.txt\n"
+    assert local_store[0]._ssh_slurp("ls {}".format(dirpath)).decode("utf-8") == "my_file.txt\n"
 
     # clean up
     shutil.rmtree(os.path.join(local_store[1]))
@@ -79,7 +79,7 @@ def test_chmod(local_store):
     local_store[0]._chmod("my_empty_file", "664")
 
     # make sure permissions are correct
-    output = local_store[0]._ssh_slurp("ls -l {}".format(temppath))
+    output = local_store[0]._ssh_slurp("ls -l {}".format(temppath)).decode("utf-8")
     perms = output.split(" ")[0]
     assert perms == "-rw-rw-r--"
 
@@ -95,7 +95,7 @@ def test_move(local_store):
     local_store[0]._ssh_slurp("touch {}".format(temppath))
     local_store[0]._move("my_empty_file", "my_moved_file")
     temppath2 = os.path.join("/tmp", local_store[1], "my_moved_file")
-    assert local_store[0]._ssh_slurp("ls {}".format(temppath2)) == "{}\n".format(temppath2)
+    assert local_store[0]._ssh_slurp("ls {}".format(temppath2)).decode("utf-8") == "{}\n".format(temppath2)
 
     # test trying to overwrite a file that already exists
     with pytest.raises(RPCError):
@@ -106,7 +106,7 @@ def test_move(local_store):
     local_store[0]._ssh_slurp("rm -f {} {}".format(temppath, temppath2))
     local_store[0]._ssh_slurp("touch {}".format(temppath))
     local_store[0]._move("my_empty_file", "my_moved_file", chmod_spec=664)
-    output = local_store[0]._ssh_slurp("ls -l {}".format(temppath2))
+    output = local_store[0]._ssh_slurp("ls -l {}".format(temppath2)).decode("utf-8")
     perms = output.split(" ")[0]
     assert perms == "-rw-rw-r--"
 
@@ -124,7 +124,7 @@ def test_delete(local_store):
     assert (
         local_store[0]._ssh_slurp(
             "if [ -f {} ]; then echo file_still_exists; fi".format(temppath)
-        )
+        ).decode("utf-8")
         == ""
     )
 
@@ -135,7 +135,7 @@ def test_delete(local_store):
     assert (
         local_store[0]._ssh_slurp(
             "if [ -d {} ]; then echo dir_still_exists; fi".format(tempdir)
-        )
+        ).decode("utf-8")
         == ""
     )
 
@@ -156,7 +156,7 @@ def test_create_tempdir(local_store):
     assert len(tmppath) == len("libtmp.") + 6
     # make sure it exists on the host
     assert (
-        local_store[0]._ssh_slurp("ls -d1 {}/{}".format(tempdir, tmppath))
+        local_store[0]._ssh_slurp("ls -d1 {}/{}".format(tempdir, tmppath)).decode("utf-8")
         == "{}/{}\n".format(tempdir, tmppath)
     )
 

--- a/hera_librarian/tests/test_cli.py
+++ b/hera_librarian/tests/test_cli.py
@@ -131,4 +131,4 @@ def test_generate_parser():
 def test_main(script_runner):
     version = hera_librarian.__version__
     ret = script_runner.run("librarian", "-V")
-    assert ret.stderr == "librarian {}\n".format(version)
+    assert ret.stdout == "librarian {}\n".format(version)

--- a/hera_librarian/tests/test_cli.py
+++ b/hera_librarian/tests/test_cli.py
@@ -6,7 +6,7 @@
 
 """
 
-from __future__ import print_function, division, absolute_import
+
 import pytest
 import os
 

--- a/hera_librarian/utils.py
+++ b/hera_librarian/utils.py
@@ -169,11 +169,11 @@ def get_md5_from_path(path):
         locale.setlocale(locale.LC_COLLATE, 'C')
 
         for f in sorted(all_files()):
-            subhash = _md5_of_file(f)
+            subhash = _md5_of_file(f).encode("utf-8")
             md5.update(subhash)  # this is the hex digest, like we want
-            md5.update('  .')  # compat with command-line approach
-            md5.update(f[plen:])
-            md5.update('\n')
+            md5.update('  .'.encode("utf-8"))  # compat with command-line approach
+            md5.update(f[plen:].encode("utf-8"))
+            md5.update('\n'.encode("utf-8"))
     finally:
         locale.setlocale(locale.LC_COLLATE, prevlocale)
 

--- a/librarian_server/__init__.py
+++ b/librarian_server/__init__.py
@@ -7,7 +7,7 @@ initialize many things on module import, which is a bit lame. There are
 probably ways to work around that but things work well enough as is.
 
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 import logging
 import sys
@@ -236,7 +236,7 @@ def maybe_add_stores():
     from .dbutil import SQLAlchemyError
     from .store import Store
 
-    for name, cfg in app.config.get('add-stores', {}).iteritems():
+    for name, cfg in app.config.get('add-stores', {}).items():
         prev = Store.query.filter(Store.name == name).first()
         if prev is None:
             store = Store(name, cfg['path_prefix'], cfg['ssh_host'])

--- a/librarian_server/bgtasks.py
+++ b/librarian_server/bgtasks.py
@@ -11,7 +11,7 @@ notice at any time.
 This system requires Tornado.
 
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 __all__ = str('''
 BackgroundTask

--- a/librarian_server/dbutil.py
+++ b/librarian_server/dbutil.py
@@ -5,7 +5,7 @@
 """Generic database utilities.
 
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 __all__ = str('''
 NotNull

--- a/librarian_server/file.py
+++ b/librarian_server/file.py
@@ -4,7 +4,7 @@
 
 "Files."
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 __all__ = str('''
 File
@@ -178,8 +178,8 @@ class File (db.Model):
                 raise ServerError('cannot register %s:%s: %s', store.name, store_path, e)
 
         size = required_arg(info, int, 'size')
-        md5 = required_arg(info, unicode, 'md5')
-        type = required_arg(info, unicode, 'type')
+        md5 = required_arg(info, str, 'md5')
+        type = required_arg(info, str, 'type')
 
         from .observation import Observation
         from . import mc_integration as MC
@@ -356,11 +356,11 @@ class File (db.Model):
 
     @classmethod
     def from_dict(cls, source, info):
-        name = required_arg(info, unicode, 'name')
-        type = required_arg(info, unicode, 'type')
+        name = required_arg(info, str, 'name')
+        type = required_arg(info, str, 'type')
         ctime_unix = required_arg(info, int, 'create_time')
         size = required_arg(info, int, 'size')
-        md5 = required_arg(info, unicode, 'md5')
+        md5 = required_arg(info, str, 'md5')
 
         # obsid needs special handling: it must be present, but it can be None.
         try:
@@ -368,7 +368,7 @@ class File (db.Model):
         except KeyError:
             raise ServerError('required parameter "obsid" not provided')
 
-        if obsid is not None and not isinstance(obsid, (int, long)):
+        if obsid is not None and not isinstance(obsid, int):
             raise ServerError('parameter "obsid" should be an integer or None, but got %r', obsid)
 
         return cls(name, type, obsid, source, size, md5, datetime.datetime.fromtimestamp(ctime_unix))
@@ -560,8 +560,8 @@ def create_file_event(args, sourcename=None):
     We enforce basically no structure on the event data.
 
     """
-    file_name = required_arg(args, unicode, 'file_name')
-    type = required_arg(args, unicode, 'type')
+    file_name = required_arg(args, str, 'file_name')
+    type = required_arg(args, str, 'type')
     payload = required_arg(args, dict, 'payload')
 
     file = File.query.get(file_name)
@@ -587,7 +587,7 @@ def locate_file_instance(args, sourcename=None):
     """Tell the caller where to find an instance of the named file.
 
     """
-    file_name = required_arg(args, unicode, 'file_name')
+    file_name = required_arg(args, str, 'file_name')
 
     file = File.query.get(file_name)
     if file is None:
@@ -619,9 +619,9 @@ def set_one_file_deletion_policy(args, sourcename=None):
     the "one instance" limit still applies.
 
     """
-    file_name = required_arg(args, unicode, 'file_name')
-    deletion_policy = required_arg(args, unicode, 'deletion_policy')
-    restrict_to_store = optional_arg(args, unicode, 'restrict_to_store')
+    file_name = required_arg(args, str, 'file_name')
+    deletion_policy = required_arg(args, str, 'deletion_policy')
+    restrict_to_store = optional_arg(args, str, 'restrict_to_store')
     if restrict_to_store is not None:
         from .store import Store
         restrict_to_store = Store.get_by_name(restrict_to_store)  # ServerError if lookup fails
@@ -666,9 +666,9 @@ def delete_file_instances(args, sourcename=None):
     See File.delete_instances for a description of the safety interlocks.
 
     """
-    file_name = required_arg(args, unicode, 'file_name')
-    mode = optional_arg(args, unicode, 'mode', 'standard')
-    restrict_to_store = optional_arg(args, unicode, 'restrict_to_store')
+    file_name = required_arg(args, str, 'file_name')
+    mode = optional_arg(args, str, 'mode', 'standard')
+    restrict_to_store = optional_arg(args, str, 'restrict_to_store')
     if restrict_to_store is not None:
         from .store import Store
         restrict_to_store = Store.get_by_name(restrict_to_store)  # ServerError if lookup fails
@@ -688,9 +688,9 @@ def delete_file_instances_matching_query(args, sourcename=None):
     See File.delete_instances for a description of the safety interlocks.
 
     """
-    query = required_arg(args, unicode, 'query')
-    mode = optional_arg(args, unicode, 'mode', 'standard')
-    restrict_to_store = optional_arg(args, unicode, 'restrict_to_store')
+    query = required_arg(args, str, 'query')
+    mode = optional_arg(args, str, 'mode', 'standard')
+    restrict_to_store = optional_arg(args, str, 'restrict_to_store')
     if restrict_to_store is not None:
         from .store import Store
         restrict_to_store = Store.get_by_name(restrict_to_store)  # ServerError if lookup fails

--- a/librarian_server/mc_integration.py
+++ b/librarian_server/mc_integration.py
@@ -33,7 +33,7 @@ from .webutil import ServerError
 
 
 # M&C severity classes
-FATAL, SEVERE, WARNING, INFO = list(range(1, 5))
+FATAL, SEVERE, WARNING, INFO = range(1, 5)
 
 
 class MCManager(object):

--- a/librarian_server/mc_integration.py
+++ b/librarian_server/mc_integration.py
@@ -11,7 +11,7 @@ available, the top level of this module isn't allowed to import the `hera_mc`
 package.
 
 """
-from __future__ import absolute_import, division, print_function
+
 
 __all__ = '''
 is_file_record_invalid
@@ -33,7 +33,7 @@ from .webutil import ServerError
 
 
 # M&C severity classes
-FATAL, SEVERE, WARNING, INFO = range(1, 5)
+FATAL, SEVERE, WARNING, INFO = list(range(1, 5))
 
 
 class MCManager(object):
@@ -291,7 +291,7 @@ def create_observation_record(obsid):
     in the `initiate_upload` API call.
 
     """
-    if not isinstance(obsid, (int, long)):
+    if not isinstance(obsid, int):
         raise ValueError('obsid must be integer; got %r' % (obsid, ))  # in case a None slips in
 
     if the_mc_manager is None:

--- a/librarian_server/misc.py
+++ b/librarian_server/misc.py
@@ -2,7 +2,7 @@
 # Copyright 2016 the HERA Collaboration
 # Licensed under the BSD License.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 __all__ = str('''
 create_records
@@ -52,17 +52,17 @@ def create_records(info, sourcename):
     from .observation import ObservingSession, Observation
     from .file import File
 
-    for subinfo in info.get('sessions', {}).itervalues():
+    for subinfo in info.get('sessions', {}).values():
         obj = ObservingSession.from_dict(subinfo)
         db.session.merge(obj)
 
-    for subinfo in info.get('observations', {}).itervalues():
+    for subinfo in info.get('observations', {}).values():
         obj = Observation.from_dict(subinfo)
         db.session.merge(obj)
 
     from .mc_integration import is_file_record_invalid, note_file_created
 
-    for subinfo in info.get('files', {}).itervalues():
+    for subinfo in info.get('files', {}).values():
         obj = File.from_dict(sourcename, subinfo)
 
         # Things get slightly more complicated here because if we're linked in

--- a/librarian_server/observation.py
+++ b/librarian_server/observation.py
@@ -4,7 +4,7 @@
 
 "Observations."
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 __all__ = str('''
 ObservingSession
@@ -378,8 +378,8 @@ def describe_session_without_event(args, sourcename=None):
     "source" raw correlator data have.
 
     """
-    source = required_arg(args, unicode, 'source')
-    event_type = required_arg(args, unicode, 'event_type')
+    source = required_arg(args, str, 'source')
+    event_type = required_arg(args, str, 'event_type')
 
     # Search for files that (1) are assigned to a session, (2) come from the
     # desired source, and (3) do not (yet) have the notification event.

--- a/librarian_server/search.py
+++ b/librarian_server/search.py
@@ -8,7 +8,7 @@ This code will likely need a lot of expansion, but we'll start simple.
 
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 __all__ = str('''
 compile_search
@@ -119,19 +119,19 @@ class GenericSearchCompiler(object):
                              '-not-in-range'] = partial(self._do_num_not_in_range, attr_getter)
 
     def _do_str_matches(self, attr_getter, clause_name, payload):
-        if not isinstance(payload, unicode):
+        if not isinstance(payload, str):
             raise ServerError('can\'t parse "%s" clause: contents must be text, '
                               'but got %s', clause_name, payload.__class__.__name__)
         return attr_getter().like(payload)
 
     def _do_str_is_exactly(self, attr_getter, clause_name, payload):
-        if not isinstance(payload, unicode):
+        if not isinstance(payload, str):
             raise ServerError('can\'t parse "%s" clause: contents must be text, '
                               'but got %s', clause_name, payload.__class__.__name__)
         return (attr_getter() == payload)
 
     def _do_str_is_not(self, attr_getter, clause_name, payload):
-        if not isinstance(payload, unicode):
+        if not isinstance(payload, str):
             raise ServerError('can\'t parse "%s" clause: contents must be text, '
                               'but got %s', clause_name, payload.__class__.__name__)
         return (attr_getter() != payload)
@@ -199,21 +199,21 @@ class GenericSearchCompiler(object):
             raise ServerError('can\'t parse "%s" clause: contents must be a dict, '
                               'but got %s', clause_name, payload.__class__.__name__)
         from sqlalchemy import and_
-        return and_(*[self._compile_clause(*t) for t in payload.iteritems()])
+        return and_(*[self._compile_clause(*t) for t in payload.items()])
 
     def _do_or(self, clause_name, payload):
         if not isinstance(payload, dict) or not len(payload):
             raise ServerError('can\'t parse "%s" clause: contents must be a dict, '
                               'but got %s', clause_name, payload.__class__.__name__)
         from sqlalchemy import or_
-        return or_(*[self._compile_clause(*t) for t in payload.iteritems()])
+        return or_(*[self._compile_clause(*t) for t in payload.items()])
 
     def _do_none_of(self, clause_name, payload):
         if not isinstance(payload, dict) or not len(payload):
             raise ServerError('can\'t parse "%s" clause: contents must be a dict, '
                               'but got %s', clause_name, payload.__class__.__name__)
         from sqlalchemy import not_, or_
-        return not_(or_(*[self._compile_clause(*t) for t in payload.iteritems()]))
+        return not_(or_(*[self._compile_clause(*t) for t in payload.items()]))
 
     def _do_always_true(self, clause_name, payload):
         """We just ignore the payload."""
@@ -286,7 +286,7 @@ class ObservingSessionSearchCompiler(GenericSearchCompiler):
         self.clauses['no-file-has-event'] = self._do_no_file_has_event
 
     def _do_no_file_has_event(self, clause_name, payload):
-        if not isinstance(payload, unicode):
+        if not isinstance(payload, str):
             raise ServerError('can\'t parse "%s" clause: contents must be text, '
                               'but got %s', clause_name, payload.__class__.__name__)
 
@@ -980,7 +980,7 @@ def create_standing_order(ignored_name):
     POST data; this is basically an implementation/consistency thing.
 
     """
-    name = required_arg(request.form, unicode, 'name')
+    name = required_arg(request.form, str, 'name')
 
     try:
         if not len(name):
@@ -1011,9 +1011,9 @@ def update_standing_order(name):
         flash('No such standing order "%s"' % name)
         return redirect(url_for('standing_orders'))
 
-    new_name = required_arg(request.form, unicode, 'name')
-    new_conn = required_arg(request.form, unicode, 'conn')
-    new_search = required_arg(request.form, unicode, 'search')
+    new_name = required_arg(request.form, str, 'name')
+    new_conn = required_arg(request.form, str, 'conn')
+    new_search = required_arg(request.form, str, 'search')
 
     try:
         storder.name = new_name
@@ -1131,11 +1131,11 @@ def execute_search_ui():
     else:
         reqdata = request.args
 
-    query_type = required_arg(reqdata, unicode, 'type')
-    search_text = required_arg(reqdata, unicode, 'search')
-    output_format = optional_arg(reqdata, unicode, 'output_format', human_file_format)
-    stage_user = optional_arg(reqdata, unicode, 'stage_user', '')
-    stage_dest_suffix = optional_arg(reqdata, unicode, 'stage_dest_suffix', '')
+    query_type = required_arg(reqdata, str, 'type')
+    search_text = required_arg(reqdata, str, 'search')
+    output_format = optional_arg(reqdata, str, 'output_format', human_file_format)
+    stage_user = optional_arg(reqdata, str, 'stage_user', '')
+    stage_dest_suffix = optional_arg(reqdata, str, 'stage_dest_suffix', '')
     for_humans = True
 
     if output_format == full_path_format:
@@ -1264,10 +1264,10 @@ def execute_search_api(args, sourcename=None):
     incredibly lame but I'm not keen to build a real login system here.
 
     """
-    search_text = required_arg(args, unicode, 'search')
-    output_format = required_arg(args, unicode, 'output_format')
-    stage_user = optional_arg(args, unicode, 'stage_user', '')
-    stage_dest = optional_arg(args, unicode, 'stage_dest', '')
+    search_text = required_arg(args, str, 'search')
+    output_format = required_arg(args, str, 'output_format')
+    stage_user = optional_arg(args, str, 'stage_user', '')
+    stage_dest = optional_arg(args, str, 'stage_dest', '')
 
     if output_format == stage_the_files_json_format:
         query_type = 'instances-stores'

--- a/librarian_server/store.py
+++ b/librarian_server/store.py
@@ -17,7 +17,7 @@ instance.
 
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 __all__ = str('''
 Store
@@ -136,7 +136,7 @@ class Store (db.Model, BaseStore):
                                   self.name, dest_store_path, e)
 
             observed_size = required_arg(info, int, 'size')
-            observed_md5 = required_arg(info, unicode, 'md5')
+            observed_md5 = required_arg(info, str, 'md5')
 
             if observed_size != file.size:
                 raise ServerError('cannot complete upload to %s:%s: expected size %d; observed %d',
@@ -220,8 +220,8 @@ def initiate_upload(args, sourcename=None):
     if upload_size < 0:
         raise ServerError('"upload_size" must be nonnegative')
 
-    known_staging_store = optional_arg(args, unicode, 'known_staging_store')
-    known_staging_subdir = optional_arg(args, unicode, 'known_staging_subdir')
+    known_staging_store = optional_arg(args, str, 'known_staging_store')
+    known_staging_subdir = optional_arg(args, str, 'known_staging_subdir')
 
     if (known_staging_store is None) ^ (known_staging_subdir is None):
         raise ServerError('if "known_staging_store" is specified, so must '
@@ -282,11 +282,11 @@ def complete_upload(args, sourcename=None):
     file into its final destination.
 
     """
-    store_name = required_arg(args, unicode, 'store_name')
-    staging_dir = required_arg(args, unicode, 'staging_dir')
-    dest_store_path = required_arg(args, unicode, 'dest_store_path')
-    meta_mode = required_arg(args, unicode, 'meta_mode')
-    deletion_policy = optional_arg(args, unicode, 'deletion_policy', 'disallowed')
+    store_name = required_arg(args, str, 'store_name')
+    staging_dir = required_arg(args, str, 'staging_dir')
+    dest_store_path = required_arg(args, str, 'dest_store_path')
+    meta_mode = required_arg(args, str, 'meta_mode')
+    deletion_policy = optional_arg(args, str, 'deletion_policy', 'disallowed')
     staging_was_known = optional_arg(args, bool, 'staging_was_known', False)
     null_obsid = optional_arg(args, bool, 'null_obsid', False)
     store = Store.get_by_name(store_name)  # ServerError if failure
@@ -343,7 +343,7 @@ def register_instances(args, sourcename=None):
     `scripts/add_obs_librarian.py` for the implementation.
 
     """
-    store_name = required_arg(args, unicode, 'store_name')
+    store_name = required_arg(args, str, 'store_name')
     file_info = required_arg(args, dict, 'file_info')
 
     from .file import File, FileInstance
@@ -353,7 +353,7 @@ def register_instances(args, sourcename=None):
 
     # Sort the files to get the creation times to line up.
 
-    for full_path in sorted(file_info.iterkeys()):
+    for full_path in sorted(file_info.keys()):
         if not full_path.startswith(slashed_prefix):
             raise ServerError('file path %r should start with "%s"',
                               full_path, slashed_prefix)
@@ -560,11 +560,11 @@ def launch_file_copy(args, sourcename=None):
     """Launch a copy of a file to a remote store.
 
     """
-    file_name = required_arg(args, unicode, 'file_name')
-    connection_name = required_arg(args, unicode, 'connection_name')
-    remote_store_path = optional_arg(args, unicode, 'remote_store_path')
-    known_staging_store = optional_arg(args, unicode, 'known_staging_store')
-    known_staging_subdir = optional_arg(args, unicode, 'known_staging_subdir')
+    file_name = required_arg(args, str, 'file_name')
+    connection_name = required_arg(args, str, 'connection_name')
+    remote_store_path = optional_arg(args, str, 'remote_store_path')
+    known_staging_store = optional_arg(args, str, 'known_staging_store')
+    known_staging_subdir = optional_arg(args, str, 'known_staging_subdir')
 
     if (known_staging_store is None) ^ (known_staging_subdir is None):
         raise ServerError('if known_staging_store is provided, known_staging_subdir must be '
@@ -734,8 +734,8 @@ def initiate_offload(args, sourcename=None):
     choose *which* file instances to offload in each call.
 
     """
-    source_store_name = required_arg(args, unicode, 'source_store_name')
-    dest_store_name = required_arg(args, unicode, 'dest_store_name')
+    source_store_name = required_arg(args, str, 'source_store_name')
+    dest_store_name = required_arg(args, str, 'dest_store_name')
 
     from sqlalchemy import func
     from sqlalchemy.orm import aliased

--- a/librarian_server/tests/conftest.py
+++ b/librarian_server/tests/conftest.py
@@ -6,7 +6,7 @@
 
 """
 
-from __future__ import print_function, division, absolute_import
+
 
 import pytest
 import json

--- a/librarian_server/tests/test_search.py
+++ b/librarian_server/tests/test_search.py
@@ -6,7 +6,7 @@
 
 """
 
-from __future__ import print_function, division, absolute_import
+
 import pytest
 
 from librarian_server import search

--- a/librarian_server/tests/test_store.py
+++ b/librarian_server/tests/test_store.py
@@ -6,9 +6,9 @@
 
 """
 
-from __future__ import print_function, division, absolute_import, unicode_literals
+
 import pytest
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 
 from . import ALL_FILES, filetypes, obsids, md5sums, pathsizes
 from librarian_server import webutil

--- a/librarian_server/webutil.py
+++ b/librarian_server/webutil.py
@@ -6,7 +6,7 @@
 interface end of things.
 
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 __all__ = str('''
 AuthFailedError
@@ -45,7 +45,7 @@ def _check_authentication(auth):
 
     """
     if auth is not None:
-        for name, info in app.config['sources'].iteritems():
+        for name, info in app.config['sources'].items():
             if info['authenticator'] == auth:
                 return name
 
@@ -191,12 +191,12 @@ def _coerce(argtype, name, val):
         return val
 
     if argtype is int:
-        if not isinstance(val, (int, long)):
+        if not isinstance(val, int):
             raise ServerError('parameter "%s" should be an integer, but got %r', name, val)
         return val
 
-    if argtype is unicode:
-        if not isinstance(val, unicode):
+    if argtype is str:
+        if not isinstance(val, str):
             raise ServerError('parameter "%s" should be text, but got %r', name, val)
         return val
 

--- a/scripts/runserver.py
+++ b/scripts/runserver.py
@@ -3,7 +3,7 @@
 # Copyright 2016 the HERA Collaboration
 # Licensed under the BSD License.
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 from librarian_server import commandline
 import sys

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,6 @@ The HERA Librarian is a distributed system for managing HERA collaboration
 data products. This package provides client libraries that allow you to
 communicate with a Librarian server. It also includes the server code,
 although those modules are not installed in a standard ``pip install``.
-
-The Librarian client and server currently only run on Python 2.
 ''',
     install_requires=[
         'astropy >=2.0',


### PR DESCRIPTION
This PR upgrades the librarian to be compatible with python3 (and no longer compatible with python2). This was accomplished by using `2to3`, and then cleaning up a few issues that manifested after the conversion (mostly around bytes vs. strings). The version is also incremented to 1.0.0, to signify an incompatible break with previous versions. Going forward, the librarian server and client should be running exclusively python3.