### PR TITLE
Fix server installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
           command: |
             source ~/.bashrc
             conda activate ${ENV_NAME}
+            pip install .
             pytest hera_librarian --cov=hera_librarian --cov-report=xml:hera_librarian_coverage.xml --cov-report=term
             pytest librarian_server --cov=librarian_server --cov-report=xml:librarian_server_coverage.xml --cov-report=term
       - save_cache:

--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 *~
 .coverage
 *coverage.xml
+pip-wheel-metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version *next* (not yet released)
 
+# Version 1.0.1 (2019 Oct 6)
+- Use setuptools_scm for versioning.
+- Add documentation for quickly setting up a librarian server.
+
 
 # Version 1.0.0 (2019 Sep 19)
 

--- a/README.md
+++ b/README.md
@@ -6,19 +6,17 @@ database and presents a nice frontend, and Python client code that can make
 various requests of one or more servers.
 
 All of the server code is in a subdirectory called `server`. See
-[the README there](librarian_packages/server/README.md) for
+[the README there](librarian_server/README.md) for
 information on how to run a server.
 
 Besides the server, this repository provides a Python module,
 `hera_librarian`, that lets you talk to one *or more* Librarians
-programmatically. Documentation not yet available. Install it with
-[pip](https://pip.pypa.io/en/stable/) or
-
+programmatically. Some documentation is available
+[here](docs/Accessing.md). Install it with
 ```
-python setup.py install
+pip install .
 ```
-
-in the `hera_librarian` subdirectory.
+from the top level of the repository.
 
 
 ## Documentation

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,5 +1,6 @@
+# -*- coding: utf-8 -*-
 # Copyright 2016 the HERA Collaboration
-# Licensed under the MIT License.
+# Licensed under the 2-clause BSD License.
 
 [alembic]
 script_location = alembic

--- a/alembic/backport_instances.sql
+++ b/alembic/backport_instances.sql
@@ -1,5 +1,5 @@
 -- Copyright 2016 the HERA Collaboration
--- Licensed under the MIT License
+-- Licensed under the 2-clause BSD License
 --
 -- Use this script to seed the "alembic_version" table on instances
 -- of the Librarian database that have already been deployed. The

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -7,11 +7,6 @@ migration stuff.
 
 """
 
-
-# A hack so that we can get the librarian_server module.
-import sys
-sys.path.insert(0, '.')
-
 from alembic import context
 
 from logging.config import fileConfig

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,11 +1,16 @@
 # -*- mode: python; coding: utf-8 -*-
 # Copyright 2016 the HERA Collaboration
-# Licensed under the MIT License.
+# Licensed under the 2-clause BSD License.
 
 """This script is some boilerplate needed by Alembic to do its fancy database
 migration stuff.
 
 """
+
+# A hack so that we can get the librarian_server module.
+import sys
+sys.path.insert(0, '.')
+
 
 from alembic import context
 

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,6 +1,6 @@
 # -*- mode: python; coding: utf-8 -*-
 # Copyright 2017 the HERA Collaboration
-# Licensed under the MIT License.
+# Licensed under the 2-clause BSD License.
 
 """${message}
 

--- a/alembic/versions/0e0e6d02a01a_add_index_on_fileevent_name.py
+++ b/alembic/versions/0e0e6d02a01a_add_index_on_fileevent_name.py
@@ -1,5 +1,6 @@
+# -*- coding: utf-8 -*-
 # Copyright 2016 the HERA Collaboration
-# Licensed under the MIT License.
+# Licensed under the 2-clause BSD License.
 
 """Add index on FileEvent.name.
 

--- a/alembic/versions/464899566429_make_file_obsids_optional.py
+++ b/alembic/versions/464899566429_make_file_obsids_optional.py
@@ -1,5 +1,6 @@
+# -*- coding: utf-8 -*-
 # Copyright 2016-2017 the HERA Collaboration
-# Licensed under the MIT License.
+# Licensed under the 2-clause BSD License.
 
 """Make File obsids optional.
 

--- a/alembic/versions/71df5b41ae41_initial_schema.py
+++ b/alembic/versions/71df5b41ae41_initial_schema.py
@@ -1,6 +1,6 @@
 # -*- mode: python; coding: utf-8 -*-
 # Copyright 2016 the HERA Collaboration
-# Licensed under the MIT License.
+# Licensed under the 2-clause BSD License.
 
 """Initial schema.
 

--- a/alembic/versions/b02eb31402b1_add_index_on_fileinstance_name.py
+++ b/alembic/versions/b02eb31402b1_add_index_on_fileinstance_name.py
@@ -1,5 +1,6 @@
+# -*- coding: utf-8 -*-
 # Copyright 2017 the HERA Collaboration
-# Licensed under the MIT License.
+# Licensed under the 2-clause BSD License.
 
 """add index on FileInstance.name
 

--- a/alembic/versions/bc996bc8dc1c_add_fileinstance_deletion_policy.py
+++ b/alembic/versions/bc996bc8dc1c_add_fileinstance_deletion_policy.py
@@ -1,5 +1,6 @@
+# -*- coding: utf-8 -*-
 # Copyright 2016 the HERA Collaboration
-# Licensed under the MIT License.
+# Licensed under the 2-clause BSD License.
 
 """Add FileInstance.deletion_policy.
 

--- a/ci/hl_client.cfg
+++ b/ci/hl_client.cfg
@@ -1,0 +1,8 @@
+{
+    "connections": {
+	"TestUser": {
+	    "url": "http://localhost:21108/",
+	    "authenticator": "I am a bot"
+	}
+    }
+}

--- a/docs/Accessing.md
+++ b/docs/Accessing.md
@@ -48,12 +48,11 @@ your own laptop*, if the port forward is in effect.
 To make the Librarian client programs available, you need to do a standard
 
 ```
-python setup.py install
+pip install .
 ```
 
-from the [top level of this repository](..). This should install scripts like
-[librarian_locate_file.py](../scripts/librarian_locate_file.py) into your
-shell path.
+from the [top level of this repository](..). This should install the main
+librarian script (invoked by running `librarian`) into your shell path.
 
 You also need to create a file called `~/.hl_client.cfg`, which tells the
 programs how they can connect to a Librarian server. Importantly, this
@@ -96,7 +95,7 @@ If everything is working and you believe that you have a working connection to
 the NRAO Librarian, the following command should print out an SSH-friendly file path:
 
 ```
-librarian_locate_file.py local zen.2458030.17452.auto_specs.png
+librarian locate-file local zen.2458030.17452.auto_specs.png
 ```
 
 Above we have assumed that your connection to the NRAO Librarian is named
@@ -120,5 +119,5 @@ Sorry: there’s no clean documentation right now. You can read the source code
 to the command-line programs to see what they do, and read
 [the source code to the client module](../hera_librarian/__init__.py) to see
 what APIs are available. The corresponding
-[server code](../server/librarian_server/) often has fairly extensive internal
+[server code](../librarian_server/) often has fairly extensive internal
 documentation describing arguments and semantics.

--- a/docs/Administration.md
+++ b/docs/Administration.md
@@ -33,4 +33,4 @@ pg_dump -F custom -f $SITENAME-$(date +%Y%m%d).pgdump $DB_NAME
 
 The database can then be restored with `pg_restore`. These backups can be
 ingested into the Librarian itself using the `--null-obsid` option of
-`upload_to_librarian.py`.
+`librarian upload`.

--- a/docs/Index.md
+++ b/docs/Index.md
@@ -19,4 +19,4 @@ These files document the Librarian, the data-management system used by the
 ### Credits
 
 The HERA Librarian has been developed by the HERA Collaborition and is licensed
-under the MIT License. The primary author is Peter K. G. Williams.
+under the 2-clause BSD License. The primary author is Peter K. G. Williams.

--- a/docs/Ingesting.md
+++ b/docs/Ingesting.md
@@ -3,24 +3,22 @@
 Say you have created a shiny new data file that deserves to be enshrined in
 the Librarian. How do you make that happen?
 
-You should use the [upload_to_librarian.py](../scripts/upload-to-librarian.py)
-program. This tool uses the Librarian “client” modules, so you need to set
-those up first as described in
+You should use the `librarian upload` command. This tool uses the Librarian
+"client" modules, so you need to set those up first as described in
 [Programmatic Access to the Librarian](#programmatic-access-to-the-librarian).
 
-After installing the client modules, the
-[upload_to_librarian.py](../scripts/upload-to-librarian.py) script should be
-visible in your path. You can run it with the `--help` option to see its
-self-contained help. The basic usage format is:
+After installing the client modules, the `librarian` script should be visible in
+your path. You can run the `librarian upload` subcommand with the `--help`
+option to see its self-contained help. The basic usage format is:
 
 ```
-upload_to_librarian.py {connection} {local-path} {dest-path}
+librarian upload {connection} {local-path} {dest-path}
 ```
 
 For instance:
 
 ```
-upload_to_librarian.py human@folio zen.2557561.66007.phases.hdf 2557561/zen.2557561.66007.phases.hdf
+librarian upload human@folio zen.2557561.66007.phases.hdf 2557561/zen.2557561.66007.phases.hdf
 ```
 
 *The name of your file is important for several reasons*. First, obviously,
@@ -61,8 +59,8 @@ associated with an obsid. However, there are some files for which this doesn’t
 make sense — e.g., database backup files, as mentioned in the
 [Administration](./Administration.md) page.
 
-You can upload such a file by adding the `--null-obsid` option to the
-`upload_to_librarian.py` command. By making you have to explicitly indicate
-that you want your file to be unassociated with an obsid, we prevent
-accidental ingestion of files that *should* have an obsid but for which the
-matching scheme identified above failed.
+You can upload such a file by adding the `--null-obsid` option to the `librarian
+upload` command. By making you have to explicitly indicate that you want your
+file to be unassociated with an obsid, we prevent accidental ingestion of files
+that *should* have an obsid but for which the matching scheme identified above
+failed.

--- a/docs/Staging.md
+++ b/docs/Staging.md
@@ -82,7 +82,7 @@ launch a stage directly from the command line.
 An example command is:
 
 ```
-librarian_stage_files.py local /lustre/aoc/projects/hera/pwilliam/demo \
+librarian stage-files local /lustre/aoc/projects/hera/pwilliam/demo \
  '{"name-matches": "zen.2457644.%.xx.HH.uvc"}'
 ```
 
@@ -99,7 +99,7 @@ the shell. Note that single-quoted shell strings do not have shell-variable
 substitutions applied, though. When in doubt, just use the `echo` command to
 see what the shell is doing to what you type.
 
-The `librarian_stage_files.py` command also has an option called `--wait` or
+The `librarian stage-files` subcommand also has an option called `--wait` or
 `-w`. When specified, the program will not exit until the staging process is
 done. This is useful for scripting.
 
@@ -109,11 +109,12 @@ done. This is useful for scripting.
 The standard `hera_librarian` client module includes an API call that will
 launch a staging operation. Once you’ve created a `LibrarianClient` client
 object, the method is `launch_local_disk_stage_operation`. See the
-implementation of the `librarian_stage_files.py` program for a usage example.
+implementation of the `librarian stage-files` function in the
+[cli module](../hera_librarian/cli.py) for a usage example.
 
 Right now, there is no built-in support for the client to wait for the staging
 operation to complete. If you want that functionality, copy what
-`librarian_stage_files.py` does.
+`librarian stage-files` does.
 
 
 ## Esoterica

--- a/hera_librarian/base_store.py
+++ b/hera_librarian/base_store.py
@@ -347,7 +347,7 @@ class BaseStore (object):
         import json
         rec_text = json.dumps(rec_info)
 
-        command = 'upload_to_librarian.py --meta=json-stdin%s %s %s %s' % (
+        command = 'librarian upload --meta=json-stdin%s %s %s %s' % (
             pre_staged_arg, conn_name, self._path(local_store_path), remote_store_path)
         return self._ssh_slurp(command, input=rec_text)
 
@@ -364,7 +364,7 @@ class BaseStore (object):
         feature.
 
         """
-        c = ("librarian_offload_helper.py --name '%s' --pp '%s' --host '%s' "
+        c = ("librarian offload-helper --name '%s' --pp '%s' --host '%s' "
              "--destrel '%s' '%s'" % (dest_store.name, dest_store.path_prefix,
                                       dest_store.ssh_host, dest_rel, self._path(local_store_path)))
         return self._ssh_slurp(c)

--- a/librarian_server/README.md
+++ b/librarian_server/README.md
@@ -4,8 +4,13 @@ The HERA Librarian Server
 This directory contains tools needed to run the Librarian server.
 
 The bulk of the code is contained in a module named `librarian_server` located
-in this directory. It is *not* intended to be installed anywhere system-wide,
-and it should be considered private to the server.
+in this directory. It is installed alongside the `hera_librarian` client module,
+and the additional dependencies required to run the server can be installed
+using
+```
+pip install .[server]
+```
+from the top level of the repo.
 
 The server state is backed by a database. We use
 [Alembic](http://alembic.zzzcomputing.com/) to manage the evolution of the
@@ -19,11 +24,11 @@ A Librarian installation requires:
 
 1. A bunch of computers that store data (the “stores”)
 1. A database server
-1. A machine running the Librarian Flask server. This could potentially be
+1. A machine running the Librarian web server. This could potentially be
    one of the stores or the database server.
 
 The server machine and store machines need to be able to SSH into each other
-without passwords. The machine running the Flask server needs a Python
+without passwords. The machine running the web server needs a Python
 installation with the following modules:
 
 1. [flask](http://flask.pocoo.org/)
@@ -31,43 +36,48 @@ installation with the following modules:
 1. [sqlalchemy](http://www.sqlalchemy.org/)
 1. [flask-sqlalchemy](http://flask-sqlalchemy.pocoo.org/)
 1. Whichever database driver sqlalchemy will need to talk to your database server.
-1. [aipy](https://github.com/AaronParsons/aipy)
+1. [aipy](https://github.com/HERA-Team/aipy)
 1. [numpy](http://www.numpy.org/)
 1. [astropy](http://www.astropy.org/)
 1. [tornado](http://www.tornadoweb.org/) optionally, for robust HTTP service
 1. [alembic](http://alembic.zzzcomputing.com/)
+1. [pyuvdata](https://github.com/RadioAstronomySoftwareGroup/pyuvdata)
 
 A standard Anaconda Python installation can provide all of these except
-`flask-sqlalchemy`, `alembic`, and `aipy`. All of these except `aipy` are
-easily installable with `pip`.
+`aipy` and `pyuvdata`. These are available through `pip` or the `conda-forge`
+channel, like so:
+```
+conda install -c conda-forge aipy pyuvdata
+```
 
 To set up a new Librarian server:
 
 1. Create a database for the Librarian using the system of your choice. The
    on-site system uses [Postgres](https://www.postgresql.org/) so this will
    always be the best-supported option.
-1. Create a file in this directory called `server-config.json`, using
-   `server-config.sample.json` as a template. There are a handful of values
-   that need to be set — most importantly, the
-   [SQLAlchemy database URL](http://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls)
-   needed to talk to your database.
-1. From this directory, run `alembic upgrade head` to initialize the database
-   schema using Alembic’s infrastructure.
-1. Finally, from this directory, run `./runserver.py` to boot the server.
+1. Create a file called `server-config.json`, using `server-config.sample.json`
+   as a template. There are a handful of values that need to be set — most
+   importantly, the [SQLAlchemy database
+   URL](http://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls)
+   needed to talk to your database. Once this file is created, you **must**
+   export its full path to the `LIBRARIAN_CONFIG_PATH` shell variable.
+1. From the top level directory, run `alembic upgrade head` to initialize the
+   database schema using Alembic’s infrastructure.
+1. Finally, run `runserver.py` to boot the server.
 
 
 Updating the Database Schema
 ----------------------------
 
 When in the course of human events it becomes necessary for a developer to
-change the schema of the Librarian database, the develop must use Alembic to
+change the schema of the Librarian database, the developer must use Alembic to
 manage the schema evolution. The workflow for *specifying* a schema change is
 this:
 
 1. Read [the Alembic documentation](http://alembic.zzzcomputing.com/) to
    familiarize yourself with how it works.
 1. Change the schema in the files in the `librarian_server` module as needed.
-1. In this direcotry, run `alembic revision --autogenerate -m
+1. In the main repo directory, run `alembic revision --autogenerate -m
    $DESCRIPTION_OF_CHANGE`, where `$DESCRIPTION_OF_CHANGE` is a terse
    description of the change to the schema. Alembic will do its best to figure
    out what you did to the schema and record the changes in a new file in the
@@ -83,12 +93,74 @@ The workflow for *deploying* a schema change on a given Librarian instance is:
 
 1. Shut down the running Librarian server.
 1. Use Git to pull in a version of the codebase with the changed schema.
-1. In this directory, run `alembic upgrade head` to update the database schema
-   to the newest version. You may need to set the environment variable
-   `LIBRARIAN_CONFIG_PATH` to point to the Librarian server configuration file
-   if it does not live in the default location of `./server-config.json`.
+1. From the main repo directory, run `alembic upgrade head` to update the
+   database schema to the newest version. You may need to set the environment
+   variable `LIBRARIAN_CONFIG_PATH` to point to the Librarian server
+   configuration file if it has not already been set.
 1. Restart the Librarian server.
 
 Obviously, you should not deploy a schema change to one of the production
-servers (on-site, Penn) until you are sure that the associated change is one
+servers (on-site, NRAO) until you are sure that the associated change is one
 that we want to commit to.
+
+
+Quick and Dirty Guide for Installing and Testing a Librarian Server
+===================================================================
+
+Here is a quick introduction for how to stand up a librarian server and upload
+a file to it. We assume the user is using Postgres as the backing database,
+and is running on Ubuntu 18.04.
+
+1. Install the postgres package:
+   ```
+   sudo apt update
+   sudo apt install postgresql postgresql-contrib
+   ```
+1. Set up postgres to work with the testing database. Note the name of the
+   database is defined in the server config file. This database name matches the
+   one defined in [the sample config file](../ci/server-config-ci.json):
+   ```
+   sudo su postgres
+   psql -c "create database librarian_test;"
+   psql -c "create user <your_username>;"
+   exit
+   ```
+1. Clone the librarian repo:
+   ```
+   git clone https://github.com/HERA-Team/librarian.git
+   ```
+1. Install the librarian package and dependencies:
+   ```
+   cd librarian
+   pip install .[server]
+   ```
+1. Point to the testing server config file:
+   ```
+   export LIBRARIAN_CONFIG_PATH=`pwd`/ci/server-config-ci.json
+   ```
+1. Use `alembic` to update the database schema:
+   ```
+   alembic upgrade head
+   ```
+1. Copy the high-level client config file to the proper location:
+   ```
+   cp ci/hl_client.cfg ~/.hl_client.cfg
+   ```
+1. Make a scratch directory for the librarian to use as a "store". These are
+   defined in the `add-stores` section of the server config file:
+   ```
+   mkdir /tmp/librarian
+   ```
+1. Launch the librarian server:
+   ```
+   runserver.py
+   ```
+1. In a separate terminal, attempt to upload a file to the running librarian
+   server:
+   ```
+   librarian upload --null-obsid TestUser README.md foo/README.md
+   ```
+1. Verify that the file was successfully uploaded to the librarian. In a web
+   browser, navigate to `localhost:21108`. You should use the authenticator
+   string `I am a human`. After authenticating, you should see `README.md`
+   listed under "Most Recent Files". Success!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools>=30.3.0", "wheel", "setuptools_scm"]

--- a/scripts/runserver.py
+++ b/scripts/runserver.py
@@ -4,7 +4,12 @@
 # Licensed under the BSD License.
 
 
-
-from librarian_server import commandline
 import sys
+try:
+    from librarian_server import commandline
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(
+        "librarian_server package not found; please install with "
+        "`pip install .[sever]` in the librarian repo and try again."
+    )
 commandline(sys.argv)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019 The HERA Collaboration
+# Licensed under the 2-clause BSD License
+
 import os
 import re
 import codecs
@@ -8,69 +12,57 @@ package_name = "hera_librarian"
 # get the version from __init__.py
 here = os.path.abspath(os.path.dirname(__file__))
 
+
 def read(*parts):
-    with codecs.open(os.path.join(here, *parts), 'r') as fp:
+    with codecs.open(os.path.join(here, *parts), "r") as fp:
         return fp.read()
 
-def find_version(*file_paths):
-    version_file = read(*file_paths)
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                              version_file, re.M)
-    if version_match:
-        return version_match.group(1)
-    raise RuntimeError("Unable to find version string.")
 
 packages = find_packages(exclude=["*.tests"])
 
+
 setup(
     name=package_name,
-    version=find_version(package_name, "__init__.py"),
-    author='HERA Team',
-    author_email='hera@lists.berkeley.edu',
-    url='https://github.com/HERA-Team/librarian/',
-    license='BSD',
-    description='A client for the HERA Librarian data management system',
-    long_description='''\
+    version="1.0.1",
+    author="HERA Team",
+    author_email="hera@lists.berkeley.edu",
+    url="https://github.com/HERA-Team/librarian/",
+    license="BSD",
+    description="A client for the HERA Librarian data management system",
+    long_description="""\
 The HERA Librarian is a distributed system for managing HERA collaboration
 data products. This package provides client libraries that allow you to
 communicate with a Librarian server. It also includes the server code,
 although those modules are not installed in a standard ``pip install``.
-''',
-    install_requires=[
-        'astropy >=2.0',
-    ],
-    tests_require=[
-        'pytest',
-        'pytest-datafiles',
-        'pytest-console-scripts',
-    ],
+""",
+    install_requires=["astropy >=2.0"],
+    tests_require=["pytest", "pytest-datafiles", "pytest-console-scripts"],
     packages=packages,
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: BSD License',
-        'Topic :: Scientific/Engineering :: Astronomy',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: BSD License",
+        "Topic :: Scientific/Engineering :: Astronomy",
     ],
     extras_require={
-        'server': [
-            'aipy',
-            'alembic',
-            'astropy >=2.0',
-            'flask',
-            'flask-sqlalchemy',
-            'hera-librarian',
-            'numpy',
-            'psycopg2',
-            'pyuvdata',
-            'sqlalchemy',
-        ],
+        "server": [
+            "aipy",
+            "alembic",
+            "astropy >=2.0",
+            "flask",
+            "flask-sqlalchemy",
+            "hera-librarian",
+            "numpy",
+            "psycopg2",
+            "pyuvdata",
+            "sqlalchemy",
+        ]
     },
     scripts=[
         "scripts/librarian_stream_file_or_directory.sh",
+        "scripts/runserver.py",
     ],
-    entry_points={
-        "console_scripts": [
-            "librarian=hera_librarian.cli:main",
-        ],
-    },
+    entry_points={"console_scripts": ["librarian=hera_librarian.cli:main"]},
+    use_scm_version=True,
+    setup_requires=["setuptools_scm", "setuptools_scm_git_archive"],
 )


### PR DESCRIPTION
This PR addresses some issues installing the server that came up after the package reorganization and python2 -> 3 migration. The documentation has also been overhauled, largely to address the new unification of librarian scripts. A new section on a series of steps to quickly install and test the librarian has also been added.