### PR TITLE
python3 server installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,13 @@
 *.pyc
 *.pyo
 __pycache__
-/*.egg-info
+*.egg-info
 /build
 /dist
 *~
 .coverage
 *coverage.xml
 pip-wheel-metadata
+eggs/
+.eggs/
+*.egg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Version *next* (not yet released)
 
-# Version 1.0.3 (2019 Oct ?)
+# Version 1.0.3 (2019 Oct 22)
 
+- Make background tasks work in python3. For now this comes at the
+  expense of multiple background worker threads.
 - Fix distribution so server works from system-wide installation.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Version *next* (not yet released)
 
+# Version 1.0.3 (2019 Oct ?)
+
+- Fix distribution so server works from system-wide installation.
+
+
 # Version 1.0.2 (2019 Oct 6)
 
 - Fix server versioning for tagged releases.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include *.md
+include LICENSE
+include scripts/*.sh
+recursive-include docs *
+graft librarian_server/templates

--- a/README.md
+++ b/README.md
@@ -5,14 +5,13 @@ site. There is a Flask-based server that keeps track of everything using a
 database and presents a nice frontend, and Python client code that can make
 various requests of one or more servers.
 
-All of the server code is in a subdirectory called `server`. See
-[the README there](librarian_server/README.md) for
-information on how to run a server.
+All of the server code is in a subdirectory called `librarian_server`. See [the
+README there](librarian_server/README.md) for information on how to run a
+server.
 
-Besides the server, this repository provides a Python module,
-`hera_librarian`, that lets you talk to one *or more* Librarians
-programmatically. Some documentation is available
-[here](docs/Accessing.md). Install it with
+Besides the server, this repository provides a Python module, `hera_librarian`,
+that lets you talk to one *or more* Librarians programmatically. Some
+documentation is available [here](docs/Accessing.md). Install it with
 ```
 pip install .
 ```

--- a/ci/install-circle.sh
+++ b/ci/install-circle.sh
@@ -3,6 +3,7 @@ set -xe
 # get conda set up
 apt-get update; apt-get install -y gcc g++ openssh-server rsync
 conda config --set always_yes yes --set changeps1 no
+conda install setuptools
 conda update -q conda
 conda config --add channels conda-forge
 conda info -a

--- a/ci/install-circle.sh
+++ b/ci/install-circle.sh
@@ -3,7 +3,7 @@ set -xe
 # get conda set up
 apt-get update; apt-get install -y gcc g++ openssh-server rsync
 conda config --set always_yes yes --set changeps1 no
-conda install setuptools
+conda install setuptools pip
 conda update -q conda
 conda config --add channels conda-forge
 conda info -a

--- a/ci/server-config-ci.json
+++ b/ci/server-config-ci.json
@@ -15,8 +15,6 @@
 
     "n_server_processes": 1,
 
-    "n_worker_threads": 8,
-
     "standing_order_mode": "normal",
 
     "obsid_inference_mode": "hera",

--- a/docs/server-config.sample.json
+++ b/docs/server-config.sample.json
@@ -49,9 +49,6 @@
     # setup
     #"n_server_processes": 1,
 
-    # Use this many worker threads for background activities.
-    #"n_worker_threads": 8,
-
     # Control over processing of standing orders. Default "normal". If "disabled",
     # then standing order uploads are disabled. (Implemented for the time that Penn
     # ran out of disk space.) If "nighttime", uploads are *not* launched between

--- a/hera_librarian/base_store.py
+++ b/hera_librarian/base_store.py
@@ -349,7 +349,7 @@ class BaseStore (object):
 
         command = 'librarian upload --meta=json-stdin%s %s %s %s' % (
             pre_staged_arg, conn_name, self._path(local_store_path), remote_store_path)
-        return self._ssh_slurp(command, input=rec_text)
+        return self._ssh_slurp(command, input=rec_text.encode("utf-8"))
 
     def upload_file_to_local_store(self, local_store_path, dest_store, dest_rel):
         """Fire off an rsync process on the store that will upload a given file to

--- a/hera_librarian/cli.py
+++ b/hera_librarian/cli.py
@@ -489,7 +489,7 @@ def add_file_event(args):
 
         payload[key] = value
 
-    path = os.path.basename(args.path)  # in case user provided a real filesystem path
+    path = os.path.basename(args.file_path)  # in case user provided a real filesystem path
 
     # Let's do it
     client = LibrarianClient(args.conn_name)

--- a/hera_librarian/cli.py
+++ b/hera_librarian/cli.py
@@ -539,7 +539,7 @@ def launch_copy(args):
 
     # Let's do it
     file_name = os.path.basename(args.file_name)  # in case the user has spelled out a path
-    client = hera_librarian.LibrarianClient(args.source_conn_name)
+    client = LibrarianClient(args.source_conn_name)
 
     try:
         client.launch_file_copy(file_name, args.dest_conn_name, remote_store_path=args.dest,

--- a/librarian_server/__init__.py
+++ b/librarian_server/__init__.py
@@ -223,7 +223,7 @@ def commandline(argv):
             # anything to do with our standing orders.
             from tornado.ioloop import IOLoop
             from . import search
-            IOLoop.instance().add_callback(search.queue_standing_order_copies)
+            IOLoop.current().add_callback(search.queue_standing_order_copies)
             search.register_standing_order_checkin()
 
         # Hack the logger to indicate which server we are.
@@ -239,12 +239,10 @@ def commandline(argv):
         app.run(host=host, port=port, debug=debug)
     elif server == 'tornado':
         from tornado.ioloop import IOLoop
-        IOLoop.instance().start()
+        IOLoop.current().start()
     else:
         print('error: unknown server type %r' % server, file=sys.stderr)
         sys.exit(1)
-
-    bgtasks.maybe_wait_for_threads_to_finish()
 
 
 def maybe_add_stores():

--- a/librarian_server/bgtasks.py
+++ b/librarian_server/bgtasks.py
@@ -181,6 +181,7 @@ class TaskManager(object):
 
         task._manager = self
 
+        task.submit_time = time.time()
         self.tasks.append(task)
         await _thread_wrapper(task)
 

--- a/librarian_server/bgtasks.py
+++ b/librarian_server/bgtasks.py
@@ -21,10 +21,9 @@ get_unfinished_task_count
 ''').split()
 
 import time
+import asyncio
 
 from tornado.ioloop import IOLoop
-
-
 from flask import flash, redirect, render_template, url_for
 
 from . import app, db, logger
@@ -32,7 +31,7 @@ from .dbutil import NotNull
 from .webutil import ServerError, json_api, login_required, optional_arg, required_arg
 
 
-class BackgroundTask (object):
+class BackgroundTask(object):
     """A class implementing a background task.
 
     Instances of this task are also used by the Librarian to keep track of its
@@ -100,7 +99,7 @@ MIN_TASK_LIST_LENGTH = 20  # don't purge tasks if more than these are left
 TASK_LINGER_TIME = 600  # seconds
 
 
-def _thread_wrapper(task):
+async def _thread_wrapper(task):
     task.start_time = time.time()
 
     try:
@@ -112,10 +111,10 @@ def _thread_wrapper(task):
 
     task.finish_time = time.time()
     task.exception = exc
-    IOLoop.instance().add_callback(_wrapup_wrapper, task, retval, exc)
+    IOLoop.current().add_callback(_wrapup_wrapper, task, retval, exc)
 
 
-def _wrapup_wrapper(task, thread_retval, thread_exc):
+async def _wrapup_wrapper(task, thread_retval, thread_exc):
     try:
         task.wrapup_function(thread_retval, thread_exc)
     except Exception as e:
@@ -128,7 +127,7 @@ def _wrapup_wrapper(task, thread_retval, thread_exc):
     the_task_manager._maybe_purge_tasks()
 
 
-class TaskManager (object):
+class TaskManager(object):
     tasks = None
     """This is a list of all tasks that are pending, in processing, or have exited
     recently. Eventually we purge them but it's useful to be able to see the
@@ -164,7 +163,7 @@ class TaskManager (object):
                       if (t.finish_time is None or
                           (now - t.finish_time) < TASK_LINGER_TIME)]
 
-    def submit(self, task):
+    async def submit(self, task):
         """Submit a task to be run in the background.
 
         It may not be launched immediately if there are a lot of background
@@ -182,35 +181,15 @@ class TaskManager (object):
 
         task._manager = self
 
-        if self.worker_pool is None:
-            import multiprocessing.util
-            multiprocessing.util.log_to_stderr(5)
-            from multiprocessing.pool import ThreadPool
-            self.worker_pool = ThreadPool(app.config.get('n_worker_threads', 8))
-
-        task.submit_time = time.time()
         self.tasks.append(task)
-        self.worker_pool.apply_async(_thread_wrapper, (task,))
-
-    def maybe_wait_for_threads_to_finish(self):
-        if self.worker_pool is None:
-            return
-
-        print('Waiting for background jobs to complete ...')
-        self.worker_pool.close()
-        self.worker_pool.join()
-        print('   ... done.')
+        await _thread_wrapper(task)
 
 
 the_task_manager = TaskManager()
 
 
 def submit_background_task(task):
-    return the_task_manager.submit(task)
-
-
-def maybe_wait_for_threads_to_finish():
-    the_task_manager.maybe_wait_for_threads_to_finish()
+    return IOLoop.current().add_callback(the_task_manager.submit, task)
 
 
 def log_background_task_status():

--- a/librarian_server/file.py
+++ b/librarian_server/file.py
@@ -12,6 +12,7 @@ FileInstance
 FileEvent
 ''').split()
 
+import sys
 import datetime
 import json
 import os.path

--- a/librarian_server/search.py
+++ b/librarian_server/search.py
@@ -605,7 +605,7 @@ def _launch_copy_timeout():
         # re-queue ourselves to run again.
         from tornado.ioloop import IOLoop
         stord_logger.debug('re-scheduling timeout')
-        IOLoop.instance().call_later(DEFAULT_STANDING_ORDER_DELAY, _launch_copy_timeout)
+        IOLoop.current().call_later(DEFAULT_STANDING_ORDER_DELAY, _launch_copy_timeout)
 
 
 class StandingOrderManager(object):
@@ -676,7 +676,7 @@ class StandingOrderManager(object):
         self.launch_queued = True
         from tornado.ioloop import IOLoop
         stord_logger.debug('timeout actually scheduled')
-        IOLoop.instance().call_later(DEFAULT_STANDING_ORDER_DELAY, _launch_copy_timeout)
+        IOLoop.current().call_later(DEFAULT_STANDING_ORDER_DELAY, _launch_copy_timeout)
 
 
 the_standing_order_manager = StandingOrderManager()

--- a/setup.py
+++ b/setup.py
@@ -9,21 +9,12 @@ from setuptools import setup, find_packages
 
 package_name = "hera_librarian"
 
-# get the version from __init__.py
-here = os.path.abspath(os.path.dirname(__file__))
-
-
-def read(*parts):
-    with codecs.open(os.path.join(here, *parts), "r") as fp:
-        return fp.read()
-
-
 packages = find_packages(exclude=["*.tests"])
 
 
 setup(
     name=package_name,
-    version="1.0.1",
+    version="1.0.3",
     author="HERA Team",
     author_email="hera@lists.berkeley.edu",
     url="https://github.com/HERA-Team/librarian/",
@@ -65,4 +56,6 @@ although those modules are not installed in a standard ``pip install``.
     entry_points={"console_scripts": ["librarian=hera_librarian.cli:main"]},
     use_scm_version=True,
     setup_requires=["setuptools_scm", "setuptools_scm_git_archive"],
+    include_package_data=True,
+    zip_safe=False,
 )


### PR DESCRIPTION
This PR fixes some issues related to the server installation including templates needed to host the web interface. It also fixes background tasks, which were not calling the wrapup hook after the main thread function. Fixing this has for the moment removed the ability to have multiple background worker tasks. Adding this functionality back in will be made into an issue. There are also a series of smaller bug fixes discovered in the course of running the new version in production.