### PR TITLE
Fix handling for hdf5 files that are not uvh5

### DIFF
--- a/hera_librarian/utils.py
+++ b/hera_librarian/utils.py
@@ -81,7 +81,7 @@ def get_obsid_from_path(path):
             uv.read_uvh5(path, read_data=False, run_check_acceptability=False)
             t0 = Time(np.unique(uv.time_array)[0], scale='utc', format='jd')
             return int(np.floor(t0.gps))
-        except (IOError, ImportError):
+        except (IOError, ImportError, KeyError, OSError):
             pass
 
     return None


### PR DESCRIPTION
This PR allows for the librarian to ingest HDF5 files that are not uvh5 (and hence don't have the right keys to be ready with pyuvdata's `read` method). This fix has been running on site and allows for uploading of such files.