### PR TITLE
Async fixes

### DIFF
--- a/ci/server-config-ci.json
+++ b/ci/server-config-ci.json
@@ -15,6 +15,8 @@
 
     "n_server_processes": 1,
 
+    "n_worker_threads": 8,
+
     "standing_order_mode": "normal",
 
     "obsid_inference_mode": "hera",

--- a/docs/server-config.sample.json
+++ b/docs/server-config.sample.json
@@ -49,6 +49,9 @@
     # setup
     #"n_server_processes": 1,
 
+    # Use this many worker threads for background activities.
+    #"n_worker_threads": 8,
+
     # Control over processing of standing orders. Default "normal". If "disabled",
     # then standing order uploads are disabled. (Implemented for the time that Penn
     # ran out of disk space.) If "nighttime", uploads are *not* launched between

--- a/librarian_server/__init__.py
+++ b/librarian_server/__init__.py
@@ -223,7 +223,7 @@ def commandline(argv):
             # anything to do with our standing orders.
             from tornado.ioloop import IOLoop
             from . import search
-            IOLoop.current().add_callback(search.queue_standing_order_copies)
+            IOLoop.instance().add_callback(search.queue_standing_order_copies)
             search.register_standing_order_checkin()
 
         # Hack the logger to indicate which server we are.
@@ -239,10 +239,12 @@ def commandline(argv):
         app.run(host=host, port=port, debug=debug)
     elif server == 'tornado':
         from tornado.ioloop import IOLoop
-        IOLoop.current().start()
+        IOLoop.instance().start()
     else:
         print('error: unknown server type %r' % server, file=sys.stderr)
         sys.exit(1)
+
+    bgtasks.maybe_wait_for_threads_to_finish()
 
 
 def maybe_add_stores():

--- a/librarian_server/__init__.py
+++ b/librarian_server/__init__.py
@@ -223,7 +223,7 @@ def commandline(argv):
             # anything to do with our standing orders.
             from tornado.ioloop import IOLoop
             from . import search
-            IOLoop.instance().add_callback(search.queue_standing_order_copies)
+            IOLoop.current().add_callback(search.queue_standing_order_copies)
             search.register_standing_order_checkin()
 
         # Hack the logger to indicate which server we are.
@@ -239,7 +239,7 @@ def commandline(argv):
         app.run(host=host, port=port, debug=debug)
     elif server == 'tornado':
         from tornado.ioloop import IOLoop
-        IOLoop.instance().start()
+        IOLoop.current().start()
     else:
         print('error: unknown server type %r' % server, file=sys.stderr)
         sys.exit(1)

--- a/librarian_server/bgtasks.py
+++ b/librarian_server/bgtasks.py
@@ -21,9 +21,10 @@ get_unfinished_task_count
 ''').split()
 
 import time
-import asyncio
 
 from tornado.ioloop import IOLoop
+
+
 from flask import flash, redirect, render_template, url_for
 
 from . import app, db, logger
@@ -31,7 +32,7 @@ from .dbutil import NotNull
 from .webutil import ServerError, json_api, login_required, optional_arg, required_arg
 
 
-class BackgroundTask(object):
+class BackgroundTask (object):
     """A class implementing a background task.
 
     Instances of this task are also used by the Librarian to keep track of its
@@ -99,7 +100,7 @@ MIN_TASK_LIST_LENGTH = 20  # don't purge tasks if more than these are left
 TASK_LINGER_TIME = 600  # seconds
 
 
-async def _thread_wrapper(task):
+def _thread_wrapper(task):
     task.start_time = time.time()
 
     try:
@@ -111,10 +112,10 @@ async def _thread_wrapper(task):
 
     task.finish_time = time.time()
     task.exception = exc
-    IOLoop.current().add_callback(_wrapup_wrapper, task, retval, exc)
+    IOLoop.instance().add_callback(_wrapup_wrapper, task, retval, exc)
 
 
-async def _wrapup_wrapper(task, thread_retval, thread_exc):
+def _wrapup_wrapper(task, thread_retval, thread_exc):
     try:
         task.wrapup_function(thread_retval, thread_exc)
     except Exception as e:
@@ -127,7 +128,7 @@ async def _wrapup_wrapper(task, thread_retval, thread_exc):
     the_task_manager._maybe_purge_tasks()
 
 
-class TaskManager(object):
+class TaskManager (object):
     tasks = None
     """This is a list of all tasks that are pending, in processing, or have exited
     recently. Eventually we purge them but it's useful to be able to see the
@@ -163,7 +164,7 @@ class TaskManager(object):
                       if (t.finish_time is None or
                           (now - t.finish_time) < TASK_LINGER_TIME)]
 
-    async def submit(self, task):
+    def submit(self, task):
         """Submit a task to be run in the background.
 
         It may not be launched immediately if there are a lot of background
@@ -181,16 +182,35 @@ class TaskManager(object):
 
         task._manager = self
 
+        if self.worker_pool is None:
+            import multiprocessing.util
+            multiprocessing.util.log_to_stderr(5)
+            from multiprocessing.pool import ThreadPool
+            self.worker_pool = ThreadPool(app.config.get('n_worker_threads', 8))
+
         task.submit_time = time.time()
         self.tasks.append(task)
-        await _thread_wrapper(task)
+        self.worker_pool.apply_async(_thread_wrapper, (task,))
+
+    def maybe_wait_for_threads_to_finish(self):
+        if self.worker_pool is None:
+            return
+
+        print('Waiting for background jobs to complete ...')
+        self.worker_pool.close()
+        self.worker_pool.join()
+        print('   ... done.')
 
 
 the_task_manager = TaskManager()
 
 
 def submit_background_task(task):
-    return IOLoop.current().add_callback(the_task_manager.submit, task)
+    return the_task_manager.submit(task)
+
+
+def maybe_wait_for_threads_to_finish():
+    the_task_manager.maybe_wait_for_threads_to_finish()
 
 
 def log_background_task_status():

--- a/librarian_server/search.py
+++ b/librarian_server/search.py
@@ -605,7 +605,7 @@ def _launch_copy_timeout():
         # re-queue ourselves to run again.
         from tornado.ioloop import IOLoop
         stord_logger.debug('re-scheduling timeout')
-        IOLoop.instance().call_later(DEFAULT_STANDING_ORDER_DELAY, _launch_copy_timeout)
+        IOLoop.current().call_later(DEFAULT_STANDING_ORDER_DELAY, _launch_copy_timeout)
 
 
 class StandingOrderManager(object):
@@ -676,7 +676,7 @@ class StandingOrderManager(object):
         self.launch_queued = True
         from tornado.ioloop import IOLoop
         stord_logger.debug('timeout actually scheduled')
-        IOLoop.instance().call_later(DEFAULT_STANDING_ORDER_DELAY, _launch_copy_timeout)
+        IOLoop.current().call_later(DEFAULT_STANDING_ORDER_DELAY, _launch_copy_timeout)
 
 
 the_standing_order_manager = StandingOrderManager()

--- a/librarian_server/search.py
+++ b/librarian_server/search.py
@@ -605,7 +605,7 @@ def _launch_copy_timeout():
         # re-queue ourselves to run again.
         from tornado.ioloop import IOLoop
         stord_logger.debug('re-scheduling timeout')
-        IOLoop.current().call_later(DEFAULT_STANDING_ORDER_DELAY, _launch_copy_timeout)
+        IOLoop.instance().call_later(DEFAULT_STANDING_ORDER_DELAY, _launch_copy_timeout)
 
 
 class StandingOrderManager(object):
@@ -676,7 +676,7 @@ class StandingOrderManager(object):
         self.launch_queued = True
         from tornado.ioloop import IOLoop
         stord_logger.debug('timeout actually scheduled')
-        IOLoop.current().call_later(DEFAULT_STANDING_ORDER_DELAY, _launch_copy_timeout)
+        IOLoop.instance().call_later(DEFAULT_STANDING_ORDER_DELAY, _launch_copy_timeout)
 
 
 the_standing_order_manager = StandingOrderManager()


### PR DESCRIPTION
This PR reverts some changes that were done previously in an attempt to get background tasks working again. The secret was to pass in a reference to the parent thread's `IOLoop` and add the task finalization onto that, rather than the reference inside of the worker thread. This version seems to be running successfully on site.