### PR TITLE
Add some connectivity diagnostics infrastructure

### DIFF
--- a/ci/librarian_tests.yml
+++ b/ci/librarian_tests.yml
@@ -13,6 +13,7 @@ dependencies:
   - numpy
   - psycopg2
   - pytest
+  - pytz
   - pyuvdata
   - sqlalchemy
   - tornado

--- a/hera_librarian/__init__.py
+++ b/hera_librarian/__init__.py
@@ -110,6 +110,9 @@ class LibrarianClient (object):
     def ping(self, **kwargs):
         return self._do_http_post('ping', **kwargs)
 
+    def probe_stores(self, **kwargs):
+        return self._do_http_post('probe_stores', **kwargs)
+
     def create_file_event(self, file_name, type, **kwargs):
         """Note that keyword arguments to this function will automagically be stuffed
         inside the "payload" parameter.

--- a/hera_librarian/__init__.py
+++ b/hera_librarian/__init__.py
@@ -113,6 +113,16 @@ class LibrarianClient (object):
     def probe_stores(self, **kwargs):
         return self._do_http_post('probe_stores', **kwargs)
 
+    def stores(self):
+        """Generate a sequence of Stores that are attached to the remote Librarian."""
+
+        from .base_store import BaseStore
+        info = self.probe_stores()
+
+        for item in info['stores']:
+            yield BaseStore(item['name'], item['path_prefix'], item['ssh_host'])
+
+
     def create_file_event(self, file_name, type, **kwargs):
         """Note that keyword arguments to this function will automagically be stuffed
         inside the "payload" parameter.

--- a/hera_librarian/__init__.py
+++ b/hera_librarian/__init__.py
@@ -10,6 +10,8 @@ import urllib.request, urllib.parse, urllib.error
 from pkg_resources import get_distribution, DistributionNotFound
 
 __all__ = str('''
+all_connections
+get_client_config
 NoSuchConnectionError
 RPCError
 LibrarianClient
@@ -35,6 +37,17 @@ def get_client_config():
     with open(path, 'r') as f:
         s = f.read()
     return json.loads(s)
+
+
+def all_connections():
+    """Generate a sequence of LibrarianClient objects for all connections in the
+    configuration file.
+
+    """
+    config = get_client_config()
+
+    for name, info in config.get('connections', {}).items():
+        yield LibrarianClient(name, info)
 
 
 class RPCError (Exception):

--- a/hera_librarian/base_store.py
+++ b/hera_librarian/base_store.py
@@ -368,3 +368,15 @@ class BaseStore (object):
              "--destrel '%s' '%s'" % (dest_store.name, dest_store.path_prefix,
                                       dest_store.ssh_host, dest_rel, self._path(local_store_path)))
         return self._ssh_slurp(c)
+
+    def check_stores_connections(self):
+        """Tell the store to check its ability to connect to other Librarians and
+        *their* stores.
+
+        This just runs the command "librarian check-connections" and returns
+        its textual output. In principle this command could be given an option
+        to return its output in JSON and we could parse it, but for the
+        envisioned use cases text will be OK.
+
+        """
+        return self._ssh_slurp('librarian check-connections').decode('utf-8')

--- a/hera_librarian/cli.py
+++ b/hera_librarian/cli.py
@@ -156,11 +156,11 @@ def generate_parser():
     sub_parsers = ap.add_subparsers(metavar="command", dest="cmd")
     config_add_file_event_subparser(sub_parsers)
     config_add_obs_subparser(sub_parsers)
-    config_launch_copy_subparser(sub_parsers)
     config_assign_session_subparser(sub_parsers)
     config_delete_files_subparser(sub_parsers)
     config_initiate_offload_subparser(sub_parsers)
     config_offload_helper_subparser(sub_parsers)
+    config_launch_copy_subparser(sub_parsers)
     config_locate_file_subparser(sub_parsers)
     config_search_files_subparser(sub_parsers)
     config_set_file_deletion_policy_subparser(sub_parsers)
@@ -214,35 +214,6 @@ def config_add_obs_subparser(sub_parsers):
     sp.add_argument("paths", metavar="PATHS", nargs="+",
                     help="The paths to the files on this computer.")
     sp.set_defaults(func=add_obs)
-
-    return
-
-
-def config_launch_copy_subparser(sub_parsers):
-    # function documentation
-    doc = """Launch a copy from one Librarian to another. Note that the filename
-    argument is treated just as the name of a file known to the source Librarian:
-    it does NOT have to be a file that exists on this particular machine. The
-    source Librarian will look up an existing instance of the file (on any
-    available store) and copy it over.
-
-    """
-    hlp = "Launch a copy from one Librarian to another"
-
-    # add sub parser
-    sp = sub_parsers.add_parser("launch-copy", description=doc, help=hlp)
-    sp.add_argument("--dest", type=str,
-                    help="The path in which the file should be stored at the destination. "
-                    "Default is the same as used locally.")
-    sp.add_argument("--pre-staged", dest="pre_staged", metavar="STORENAME:SUBDIR",
-                    help="Specify that the data have already been staged at the destination.")
-    sp.add_argument("source_conn_name", metavar="SOURCE-CONNECTION-NAME",
-                    help="Which Librarian originates the copy; as in ~/.hl_client.cfg.")
-    sp.add_argument("dest_conn_name", metavar="DEST-CONNECTION-NAME",
-                    help="Which Librarian receives the copy; as in ~/.hl_client.cfg.")
-    sp.add_argument("file_name", metavar="FILE-NAME",
-                    help="The name of the file to copy; need not be a local path.")
-    sp.set_defaults(func=launch_copy)
 
     return
 
@@ -315,22 +286,31 @@ def config_initiate_offload_subparser(sub_parsers):
     return
 
 
-def config_offload_helper_subparser(sub_parsers):
+def config_launch_copy_subparser(sub_parsers):
     # function documentation
-    doc = """The Librarian launches this script on stores to implement the "offload"
-    functionality. Regular users should never need to run it.
+    doc = """Launch a copy from one Librarian to another. Note that the filename
+    argument is treated just as the name of a file known to the source Librarian:
+    it does NOT have to be a file that exists on this particular machine. The
+    source Librarian will look up an existing instance of the file (on any
+    available store) and copy it over.
 
     """
+    hlp = "Launch a copy from one Librarian to another"
+
     # add sub parser
-    # purposely don't add help for this function, to prevent users from using it accidentally
-    sp = sub_parsers.add_parser("offload-helper", description=doc)
-    sp.add_argument("--name", required=True, help="Displayed name of the destination store.")
-    sp.add_argument("--pp", required=True, help='"Path prefix" of the destination store.')
-    sp.add_argument("--host", required=True, help="Target SSH host of the destination store.")
-    sp.add_argument("--destrel", required=True, help="Destination path, relative to the path prefix.")
-    sp.add_argument("local_path", metavar="LOCAL-PATH",
-                    help="The name of the file to upload on this machine.")
-    sp.set_defaults(func=offload_helper)
+    sp = sub_parsers.add_parser("launch-copy", description=doc, help=hlp)
+    sp.add_argument("--dest", type=str,
+                    help="The path in which the file should be stored at the destination. "
+                    "Default is the same as used locally.")
+    sp.add_argument("--pre-staged", dest="pre_staged", metavar="STORENAME:SUBDIR",
+                    help="Specify that the data have already been staged at the destination.")
+    sp.add_argument("source_conn_name", metavar="SOURCE-CONNECTION-NAME",
+                    help="Which Librarian originates the copy; as in ~/.hl_client.cfg.")
+    sp.add_argument("dest_conn_name", metavar="DEST-CONNECTION-NAME",
+                    help="Which Librarian receives the copy; as in ~/.hl_client.cfg.")
+    sp.add_argument("file_name", metavar="FILE-NAME",
+                    help="The name of the file to copy; need not be a local path.")
+    sp.set_defaults(func=launch_copy)
 
     return
 
@@ -350,6 +330,26 @@ def config_locate_file_subparser(sub_parsers):
     sp.add_argument("file_name", metavar="PATH",
                     help="The name of the file to locate.")
     sp.set_defaults(func=locate_file)
+
+    return
+
+
+def config_offload_helper_subparser(sub_parsers):
+    # function documentation
+    doc = """The Librarian launches this script on stores to implement the "offload"
+    functionality. Regular users should never need to run it.
+
+    """
+    # add sub parser
+    # purposely don't add help for this function, to prevent users from using it accidentally
+    sp = sub_parsers.add_parser("offload-helper", description=doc)
+    sp.add_argument("--name", required=True, help="Displayed name of the destination store.")
+    sp.add_argument("--pp", required=True, help='"Path prefix" of the destination store.')
+    sp.add_argument("--host", required=True, help="Target SSH host of the destination store.")
+    sp.add_argument("--destrel", required=True, help="Destination path, relative to the path prefix.")
+    sp.add_argument("local_path", metavar="LOCAL-PATH",
+                    help="The name of the file to upload on this machine.")
+    sp.set_defaults(func=offload_helper)
 
     return
 

--- a/hera_librarian/cli.py
+++ b/hera_librarian/cli.py
@@ -617,10 +617,10 @@ def check_connections(args):
             any_failed = True
             continue
 
-        print('   Querying this Librarian for its stores and how to connect to them ...')
+        print('   Querying "%s" for its stores and how to connect to them ...' % client.conn_name)
 
         for store in client.stores():
-            print('   Checking ability to establish SSH connection to store "%s" (%s:%s) ...'
+            print('   Checking ability to establish SSH connection to remote store "%s" (%s:%s) ...'
                   % (store.name, store.ssh_host, store.path_prefix))
 
             try:

--- a/librarian_server/README.md
+++ b/librarian_server/README.md
@@ -42,6 +42,7 @@ installation with the following modules:
 1. [tornado](http://www.tornadoweb.org/) optionally, for robust HTTP service
 1. [alembic](http://alembic.zzzcomputing.com/)
 1. [pyuvdata](https://github.com/RadioAstronomySoftwareGroup/pyuvdata)
+1. [pytz](http://pytz.sourceforge.net/)
 
 A standard Anaconda Python installation can provide all of these except
 `aipy` and `pyuvdata`. These are available through `pip` or the `conda-forge`

--- a/librarian_server/misc.py
+++ b/librarian_server/misc.py
@@ -286,3 +286,19 @@ def index():
         recent_files=rf,
         recent_sessions=rs,
     )
+
+@app.route('/connectivity-check')
+@login_required
+def connectivity_check():
+    from .store import Store
+
+    results = {}
+
+    for store in Store.query.filter(Store.available):
+        results[store.name] = store.check_stores_connections()
+
+    return render_template(
+        'connectivity-check.html',
+        title = 'Connectivity Check',
+        results = results,
+    )

--- a/librarian_server/store.py
+++ b/librarian_server/store.py
@@ -49,7 +49,7 @@ class Store (db.Model, BaseStore):
     name = NotNull(db.String(256), unique=True)
     ssh_host = NotNull(db.String(256))
     path_prefix = NotNull(db.String(256))
-    http_prefix = db.Column(db.String(256))
+    http_prefix = db.Column(db.String(256))  # NOTE: this is totally unused
     available = NotNull(db.Boolean)
     instances = db.relationship('FileInstance', back_populates='store_object')
 
@@ -79,6 +79,17 @@ class Store (db.Model, BaseStore):
 
         """
         return BaseStore(self.name, self.path_prefix, self.ssh_host)
+
+    def to_dict(self):
+        """This function is currently only used for the /api/probe_stores command,
+        so it's a bit limited. That could be changed.
+
+        """
+        return {
+            "name": self.name,
+            "path_prefix": self.path_prefix,
+            "ssh_host": self.ssh_host,
+        }
 
     def process_staged_file(self, staged_path, dest_store_path, meta_mode,
                             deletion_policy, source_name=None, null_obsid=False):
@@ -207,6 +218,28 @@ class Store (db.Model, BaseStore):
 
 
 # RPC API
+
+@app.route('/api/probe_stores', methods=['GET', 'POST'])
+@json_api
+def probe_stores(args, sourcename=None):
+    """Get information about the stores attached to this Librarian.
+
+    The purpose of this API is to help administrators verify the configuration
+    of one or more Librarian instances. It helps make it possible for a store
+    host attached to Librarian A to check whether it is capable of connecting
+    to the store hosts attached to Librarian B.
+
+    As such, right now this command returns only the minimal amount of
+    information needed to implement this behavior. It could give more detailed
+    information.
+
+    """
+    store_list = []
+
+    for store in Store.query.filter(Store.available):
+        store_list.append(store.to_dict())
+
+    return {'stores': store_list}
 
 @app.route('/api/initiate_upload', methods=['GET', 'POST'])
 @json_api

--- a/librarian_server/templates/connectivity-check.html
+++ b/librarian_server/templates/connectivity-check.html
@@ -1,0 +1,21 @@
+{% extends "layout.html" %}
+{% block title %}{{title}}{% endblock %}
+{% block content %}
+<h1>{{title}}</h1>
+
+<p>This operation checks whether the stores attached to this Librarian are
+able to communicate with the other Librarians defined in
+their <tt>~/.hl_client.cfg</tt> files, and the stores attached to those other
+Librarians.</p>
+
+{% for name, result_text in results.items() %}
+
+<h2>Local Store "{{name}}"</h2>
+
+<p>The output of the command <tt>librarian check-connections</tt> on this store is:</p>
+
+<pre>{{result_text}}</pre>
+
+{% endfor %}
+
+{% endblock %}

--- a/librarian_server/templates/layout.html
+++ b/librarian_server/templates/layout.html
@@ -76,6 +76,7 @@
 		<li><a href="/stores">Stores</a></li>
 		<li><a href="/tasks">Tasks</a></li>
 		<li><a href="/standing-orders">Standing Orders</a></li>
+		<li><a href="/connectivity-check">Connectivity Check</a></li>
 	      </ul>
 	    </li>
 	    <li><a href="/logout">Logout</a></li>

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,8 @@ although those modules are not installed in a standard ``pip install``.
             "flask-sqlalchemy",
             "hera-librarian",
             "numpy",
-            "psycopg2",
+            "psycopg2",  # FIXME: only of using Postgres
+            "pytz",
             "pyuvdata",
             "sqlalchemy",
         ]


### PR DESCRIPTION
This PR adds several pieces of diagnostics functionality. It might be helpful to read the commits in order, but the new user-facing features are:

- A new command `librarian check-connections`, intended to be run from a Librarian store host. This will look at all of the Librarian connections defined in `~/.hl_client.cfg` and attempt to connect to each one. For each connection, it will ask for a list of all of its (available) stores and see if it can connect to *them*.
- The new Web UI endpoint `/connectivity-check`, accessible through the Admin menu, will run the above connectivity check on all stores attached to the Librarian server. This basically validates that all of the stores on *this* Librarian know how to talk to all of the stores on the *other* Librarians that this Librarian is aware of.

No user-facing documentation or tests; this is about as much time as I can spend on this stuff this week.

**Edit:** BTW, I tested this stuff by fooling around on `folio2`. Not exactly a torture test but I think it will all work?