### PR TITLE
Add globus to librarian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Version *next* (not yet released)
 
+
+# Version 1.1.0 (2019 Oct ?)
+- Add support for transfers with globus.
+
+
 # Version 1.0.2 (2019 Oct 6)
 
 - Fix server versioning for tagged releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 
 
-# Version 1.1.0 (2019 Oct ?)
-- Add support for transfers with globus.
+# Version 1.1.0 (2020 Feb 7)
+- Add support for transfers using Globus as well as associated documentation.
+- Add `librarian check-connections` command to test connectivity.
+- Improve documentation of the connectivity model.
+- Fix background tasks in python3. This adds multiple background
+  worker thread functionality again.
 
 
 # Version 1.0.3 (2019 Oct 22)

--- a/docs/Globus.md
+++ b/docs/Globus.md
@@ -2,9 +2,15 @@
 
 [Globus](https://www.globus.org/) is a service for transferring research data
 between data processing environments. The Librarian has functionality for making
-use of globus to copy instances of files between librarian stores. Globus
-installations on machines are referred to as "endpoints". The service makes a
-distinction between "Personal Endpoints", which can be made for personal
+use of globus to copy instances of files between Librarian stores. Below we
+provide a brief overview of the Globus infrastructure as it relates to
+interoperating with the Librarian, as well as provide instructions for how to
+install and configure Globus for use in the Librarian. For additional
+information about Globus and the services it provides, please refer to their
+online documentation.
+
+Globus installations on machines are referred to as "endpoints". The service
+makes a distinction between "Personal Endpoints", which can be made for personal
 machines and workstations, and "Server Endpoints", which are typically
 facility-wide installations at large computing centers (e.g., XSEDE sites,
 NERSC, etc.). When using Globus to transfer data, at least one endopint must be
@@ -68,7 +74,7 @@ been specified, the Globus client should be started. Because this process will
 be running in the background, it is best to launch the following command inside
 of a `screen` session or as part of a daemon. Run
 ```bash
-$ ./globousconnectpersonal -start
+$ ./globusconnectpersonal -start
 ```
 To confirm that the Globus installation provides the information necessary for
 the Librarian, run the following command inside of a python interpreter:
@@ -102,7 +108,8 @@ Globus. They are:
   transfers.)
 - `globus_client_id`: the Client ID of the Globus account associated with
   invoking transfers. This can be be retrieved after logging into Globus using
-  the `globus-cli` package:
+  the `globus-cli` python package (which can be installed with
+  `pip install globus-cli`):
   ```bash
   $ globus whoami
   username@globusid.org
@@ -186,9 +193,9 @@ using Globus. Additional information can be found by running `librarian upload
   for the upload.
 - `--client_id`: the Globus Client ID that should be used. In general this is
   the same as the one that would be specified in the server config file.
-- `transfer_token`: the Globus Refresh Token that should be used. As with the
+- `--transfer_token`: the Globus Refresh Token that should be used. As with the
   `client_id`, this is generally the same as the one in the server config.
-- `source_endpoint_id`: optional, again to specify the local Endpoint ID that
+- `--source_endpoint_id`: optional, again to specify the local Endpoint ID that
   should be used. If not specified, it will be inferred using the
   `LocalGlobusConnectPersonal` class provided by the `globus_sdk` module.
 

--- a/docs/Globus.md
+++ b/docs/Globus.md
@@ -130,11 +130,9 @@ A sample server config file may look in part like:
 ```json
 {
     "server": "tornado",
-    # other server options
     "use_globus": true,
     "globus_client_id": "224532bb-8a4b-4d32-8995-e1fb442be98e",
     "globus_transfer_token": "AQBX8YvVAAAAAAADxhAtF46RxjcFuoxN1oSOmEk-hBqvOejY4imMbZlC0B8THfoFuOK9rshN6TV7I0uwf0hb",
-    # more options follow
 }
 ```
 
@@ -156,7 +154,7 @@ purpose are:
 - `globus_endpoint_id`: the Globus Endpoint ID that should be used for the
   destination.
 - `globus_host_path` (optional): if the destination Globus Endpoint is a Shared
-  Endpoint (discussed more (below)[#globus-shared-endpoints]), the path to the
+  Endpoint (discussed more [below](#globus-shared-endpoints)), the path to the
   root exposed directory.
 
 For example, a `~/.hl_client.cfg` file with Globus information may look like:

--- a/docs/Globus.md
+++ b/docs/Globus.md
@@ -1,0 +1,219 @@
+# Globus Functionality in the Librarian
+
+[Globus](https://www.globus.org/) is a service for transferring research data
+between data processing environments. The Librarian has functionality for making
+use of globus to copy instances of files between librarian stores. Globus
+installations on machines are referred to as "endpoints". The service makes a
+distinction between "Personal Endpoints", which can be made for personal
+machines and workstations, and "Server Endpoints", which are typically
+facility-wide installations at large computing centers (e.g., XSEDE sites,
+NERSC, etc.). When using Globus to transfer data, at least one endopint must be
+a Server (unless the user is a "Premium" user, in which case a transfer can be
+initiated between two Personal endpoints). The current Globus functionality in
+the Librarian has been built and tested assuming that the user is running a
+Personal Endpoint (e.g., on site where data is acquired) and copying data to a
+Server Endpoint. Functionality for transferring between two Server Endpoints
+should be straightforward to add if desired.
+
+In the documentation below, we assume that the Server Endpoint has already been
+installed by the destination machine's system administrators and is part of the
+Globus network. We focus primarily on how to set up Globus on stores in the
+Librarian. To programmatically use Globus for automated transfers in the
+Librarian, it may be necessary to create a Shared Endpoint on the Globus
+Server. Please refer to the [relevant section below](#globus-shared-endpoints).
+
+### Table of Contents
+
+- [Installing Globus on Librarian
+  Stores](#installing-globus-on-librarian-stores)
+- [Adding Globus Information to Config
+  Files](#adding-globus-information-to-config-files)
+  - [Librarian Server Configuration](#librarian-server-configuration)
+  - [Remote Librarian Configuration](#remote-librarian-configuration)
+- [Using Globus from the Librarian Command-Line
+  Interface](#using-globus-from-the-librarian-command-line-interface)
+- [Globus Shared Endpoints](#globus-shared-endpoints)
+
+
+## Installing Globus on Librarian Stores
+
+In general, each store (on a different machine) known to the Librarian should
+have its own installation of Globus running. This is due to the fact that
+transfers between stores and remote Librarian instances are launched on a
+per-store basis, which in principle require unique identifiers. However, if
+there are multiple stores attached to the same machine, then multiple
+installations may not be required. The procedure outlined below should thus be
+performed for each machine (not necessarily store) in a Librarian installation.
+
+For the most up-to-date documentation for installing Globus on a Linux
+installation, please refer to the [online
+documentation](https://docs.globus.org/how-to/globus-connect-personal-linux/#globus-connect-personal-cli). As
+mentioned above, this process should be done for each machine known to the
+Librarian.
+
+After the Globus Connect Personal client has been installed for each store, the
+client must be configured to expose the store directories to the transfer
+service. Follow [these
+instructions](https://docs.globus.org/faq/globus-connect-endpoints/#how_do_i_configure_accessible_directories_on_globus_connect_personal_for_linux)
+for information on how to export specific directories. For instance, if we
+wanted to export the `/data` directory on a store, the entry in the
+`config-paths` folder might read:
+```
+/data,0,0
+```
+where the last `0` means that this path is read-only. (This option is
+appropriate for on-site installations where the flow of data is uni-directional
+to the remote Globus Server installation.) Once the desired directories have
+been specified, the Globus client should be started. Because this process will
+be running in the background, it is best to launch the following command inside
+of a `screen` session or as part of a daemon. Run
+```bash
+$ ./globousconnectpersonal -start
+```
+To confirm that the Globus installation provides the information necessary for
+the Librarian, run the following command inside of a python interpreter:
+```python
+>>> from globus_sdk import LocalGlobusConnectPersonal
+>>> local_ep = LocalGlobusConnectPersonal()
+>>> local_ep.endpoint_id
+'b19b3b45-01ae-11e6-a71c-22000bf2d559'
+```
+If no output value is generated, please ensure that the file
+`~/.globusonline/lta/client-id.txt` exists. If the home drive is shared among
+multiple store machines (e.g., due to a netboot cluster configuration),
+additional steps must be taken to ensure that the output of the `endpoint_id`
+attribute is unique to each machine and correct for a given store.
+
+
+## Adding Globus Information to Config Files
+
+Once Globus Connect Personal clients have been installed and started on
+individual machines, addtional entries must be specified in both the Librarian
+server configuration (e.g., `server-config.json`) *and* the remote Librarian
+instance list (`~/.hl_client.cfg`).
+
+### Librarian Server Configuration
+
+There are certain config entries that *must* be added for the Librarian to use
+Globus. They are:
+
+- `use_globus`: a boolean value (`true` or `false`) indicating whether the
+  Librarian should use Globus or not. (If not, `rsync` will be used for
+  transfers.)
+- `globus_client_id`: the Client ID of the Globus account associated with
+  invoking transfers. This can be be retrieved after logging into Globus using
+  the `globus-cli` package:
+  ```bash
+  $ globus whoami
+  username@globusid.org
+  $ globus get-identities "username@globusid.org"
+  224532bb-8a4b-4d32-8995-e1fb442be98e
+  ```
+- `globus_transfer_token`: the Globus "refresh token" that should be used for
+  logging into the service. Follow the steps in [this SDK documentation
+  page](https://globus-sdk-python.readthedocs.io/en/stable/tutorial/#advanced-2-refresh-tokens-never-login-again)
+  for information on how to obtain a refresh token. This allows for
+  re-authenticating with Globus without intervention from the user. (**NOTE!**
+  As mentioned in the tutorial, the refresh token should be treated as a
+  password and, accordingly, not be stored in a public place. This means not
+  uploading it to the Librarian repo as part of the config file. You have been
+  warned.)
+
+With all of these config options defined, the Librarian will attempt to use
+Globus to transfer files. If not all of these keys are defined, it will fall
+back on `rsync` for transfers. Additionally, the Librarian will fall back on
+`rsync` on a per-file basis if the Globus transfer fails for any reason, so the
+Librarian is not wholly dependent on Globus even if configured to rely primarily
+on it.
+
+A sample server config file may look in part like:
+```json
+{
+    "server": "tornado",
+    # other server options
+    "use_globus": true,
+    "globus_client_id": "224532bb-8a4b-4d32-8995-e1fb442be98e",
+    "globus_transfer_token": "AQBX8YvVAAAAAAADxhAtF46RxjcFuoxN1oSOmEk-hBqvOejY4imMbZlC0B8THfoFuOK9rshN6TV7I0uwf0hb",
+    # more options follow
+}
+```
+
+In addition to the mandatory keys outlined above, there is an optional key:
+`globus_endpoint_id`. This may be specified if there is a single Globus endpoint
+ID for each store initiating an upload (e.g., all stores are located on the same
+machine). The Librarian will use this endpoint ID instead of inferring the local
+Endpoint ID using the `LocalGlobusConnectPersonal` class as above. This option
+should *not* be specified if different stores have different Endpoint IDs,
+instead relying on the `LocalGlobusConnectPersonal.endpoint_id` attribute to
+provide the correct Endpoint ID.
+
+### Remote Librarian Configuration
+
+In addition to the Librarian server configuration, the list of remote hosts must
+have their Globus information specified. Config keys that will be used for this
+purpose are:
+
+- `globus_endpoint_id`: the Globus Endpoint ID that should be used for the
+  destination.
+- `globus_host_path` (optional): if the destination Globus Endpoint is a Shared
+  Endpoint (discussed more (below)[#globus-shared-endpoints]), the path to the
+  root exposed directory.
+
+For example, a `~/.hl_client.cfg` file with Globus information may look like:
+```json
+{
+    "connections": {
+        "remote-globus-host": {
+            "url": "http://remote-host.com:21106",
+            "authenticator": "my_authenticator",
+            "globus_endpoint_id": "b19b3b45-01ae-11e6-a71c-22000bf2d559",
+            "globus_host_path": "/export/data"
+        }
+    }
+}
+```
+
+When initiating a transfer to a remote Librarian, the client will use this
+information to construct the transfer appropriately.
+
+
+## Using Globus From the Librarian Command-Line Interface
+
+In addition to using Globus for progrommatic uploads as part of a Standing
+Order, it is possible to upload individual files to remote Librarian instances
+using Globus. Additional information can be found by running `librarian upload
+-h`. Here we provide some notes on upload options specific to Globus.
+
+- `--use_globus`: option to indicate that the client should try to use Globus
+  for the upload.
+- `--client_id`: the Globus Client ID that should be used. In general this is
+  the same as the one that would be specified in the server config file.
+- `transfer_token`: the Globus Refresh Token that should be used. As with the
+  `client_id`, this is generally the same as the one in the server config.
+- `source_endpoint_id`: optional, again to specify the local Endpoint ID that
+  should be used. If not specified, it will be inferred using the
+  `LocalGlobusConnectPersonal` class provided by the `globus_sdk` module.
+
+
+## Globus Shared Endpoints
+
+Server Endpoints in Globus typically require some type of user authentication to
+use. This authentication becomes cumbersome when attempting to run in a
+programmatic or automated fasion. To address this issue, the Globus
+infrastructure provides the concept of a "Shared Endpoint". Essentially the
+Shared Endpoint behaves in a similar manner to a Personal Endpoint, with
+optional restrictions on which Globus users are allowed to access it. For help
+with creating a Shared Endpoint on the destination machine for Globus transfers,
+please contact the system administrators of your cluster.
+
+Once a Shared Endpoint has been created, it typically only exposes a limited
+subset of the machine's filesystem. This information is listed under the "Host
+Path" of the endpoint's Overview page in Globus. When a destination location for
+a Librarian remote transfer is generated, the full absolute path is constructed
+(because when performing a transfer using `rsync`, the absolute path is required
+to ensure the file arrives where expected). To convey the information that the
+file should be copied to the location *relative to the Shared Endpoint root* as
+opposed to the filesystem root, the `globus_host_path` config option is
+used. This ensures that the first part of the destination path matching the
+Shared Endpoint's Host Path is removed from the destination file, so that the
+file is transferred to the target location.

--- a/hera_librarian/__init__.py
+++ b/hera_librarian/__init__.py
@@ -223,6 +223,10 @@ class LibrarianClient(object):
             case we assume it is a "personal" (as opposed to public)
             client. When using globus, at least one of the source_endpoint_id or
             destination_endpoint_id must be provided.
+        host_path : str, optional
+            The `host_path` of the globus store. When using shared endpoints,
+            this is the root directory presented to the client. Note that this
+            may be different from the `path_prefix` for a given store.
 
         Returns
         -------
@@ -269,11 +273,13 @@ class LibrarianClient(object):
                     source_endpoint_id = local_ep.endpoint_id
                 except ModuleNotFoundError:
                     source_endpoint_id = None
-            # get the destination_endpoint_id from config file
+            # get the relevant destination info from config file
             destination_endpoint_id = self.config.get("globus_endpoint_id", None)
+            host_path = self.config.get("globus_host_path", None)
         else:
-            source_endpiotn_id = None
+            source_endpoint_id = None
             destination_endpoint_id = None
+            host_path = None
 
         # Now, (try to) actually copy the data. This runs an SCP, potentially
         # across the globe, that in the real world will occasionally stall or
@@ -288,6 +294,7 @@ class LibrarianClient(object):
             transfer_token,
             source_endpoint_id,
             destination_endpoint_id,
+            host_path,
         )
 
         # If we made it here, though, the upload succeeded and we can tell

--- a/hera_librarian/__init__.py
+++ b/hera_librarian/__init__.py
@@ -127,19 +127,19 @@ class LibrarianClient(object):
                                   )
 
     def upload_file(
-            self,
-            local_path,
-            dest_store_path,
-            meta_mode,
-            rec_info={},
-            deletion_policy='disallowed',
-            known_staging_store=None,
-            known_staging_subdir=None,
-            null_obsid=False,
-            use_globus=False,
-            client_id=None,
-            transfer_token=None,
-            source_endpoint_id=None,
+        self,
+        local_path,
+        dest_store_path,
+        meta_mode,
+        rec_info={},
+        deletion_policy='disallowed',
+        known_staging_store=None,
+        known_staging_subdir=None,
+        null_obsid=False,
+        use_globus=False,
+        client_id=None,
+        transfer_token=None,
+        source_endpoint_id=None,
     ):
         """Upload the file located at `local_path` to the Librarian.
 
@@ -308,90 +308,113 @@ class LibrarianClient(object):
         )
 
     def register_instances(self, store_name, file_info):
-        return self._do_http_post('register_instances',
-                                  store_name=store_name,
-                                  file_info=file_info,
-                                  )
+        return self._do_http_post(
+            'register_instances',
+            store_name=store_name,
+            file_info=file_info,
+        )
 
     def locate_file_instance(self, file_name):
-        return self._do_http_post('locate_file_instance',
-                                  file_name=file_name,
-                                  )
+        return self._do_http_post(
+            'locate_file_instance',
+            file_name=file_name,
+        )
 
-    def set_one_file_deletion_policy(self, file_name, deletion_policy, restrict_to_store=None):
+    def set_one_file_deletion_policy(
+            self, file_name, deletion_policy, restrict_to_store=None
+    ):
         deletion_policy = _normalize_deletion_policy(deletion_policy)
 
-        return self._do_http_post('set_one_file_deletion_policy',
-                                  file_name=file_name,
-                                  deletion_policy=deletion_policy,
-                                  restrict_to_store=restrict_to_store,
-                                  )
+        return self._do_http_post(
+            'set_one_file_deletion_policy',
+            file_name=file_name,
+            deletion_policy=deletion_policy,
+            restrict_to_store=restrict_to_store,
+        )
 
     def delete_file_instances(self, file_name, mode='standard', restrict_to_store=None):
-        return self._do_http_post('delete_file_instances',
-                                  file_name=file_name,
-                                  mode=mode,
-                                  restrict_to_store=restrict_to_store,
-                                  )
+        return self._do_http_post(
+            'delete_file_instances',
+            file_name=file_name,
+            mode=mode,
+            restrict_to_store=restrict_to_store,
+        )
 
-    def delete_file_instances_matching_query(self, query, mode='standard', restrict_to_store=None):
-        return self._do_http_post('delete_file_instances_matching_query',
-                                  query=query,
-                                  mode=mode,
-                                  restrict_to_store=restrict_to_store,
-                                  )
+    def delete_file_instances_matching_query(
+            self, query, mode='standard', restrict_to_store=None
+    ):
+        return self._do_http_post(
+            'delete_file_instances_matching_query',
+            query=query,
+            mode=mode,
+            restrict_to_store=restrict_to_store,
+        )
 
-    def launch_file_copy(self, file_name, connection_name, remote_store_path=None,
-                         known_staging_store=None, known_staging_subdir=None):
-        return self._do_http_post('launch_file_copy',
-                                  file_name=file_name,
-                                  connection_name=connection_name,
-                                  remote_store_path=remote_store_path,
-                                  known_staging_store=known_staging_store,
-                                  known_staging_subdir=known_staging_subdir,
-                                  )
+    def launch_file_copy(
+        self,
+        file_name,
+        connection_name,
+        remote_store_path=None,
+        known_staging_store=None,
+        known_staging_subdir=None,
+    ):
+        return self._do_http_post(
+            'launch_file_copy',
+            file_name=file_name,
+            connection_name=connection_name,
+            remote_store_path=remote_store_path,
+            known_staging_store=known_staging_store,
+            known_staging_subdir=known_staging_subdir,
+        )
 
     def initiate_offload(self, source_store_name, dest_store_name):
-        return self._do_http_post('initiate_offload',
-                                  source_store_name=source_store_name,
-                                  dest_store_name=dest_store_name,
-                                  )
+        return self._do_http_post(
+            'initiate_offload',
+            source_store_name=source_store_name,
+            dest_store_name=dest_store_name,
+        )
 
     def describe_session_without_event(self, source, event_type):
-        return self._do_http_post('describe_session_without_event',
-                                  source=source,
-                                  event_type=event_type,
-                                  )
+        return self._do_http_post(
+            'describe_session_without_event',
+            source=source,
+            event_type=event_type,
+        )
 
     def launch_local_disk_stage_operation(self, user, search, dest_dir):
-        return self._do_http_post('search',
-                                  stage_user=user,
-                                  search=search,
-                                  stage_dest=dest_dir,
-                                  type='instances-stores',
-                                  output_format='stage-the-files-json',
-                                  )
+        return self._do_http_post(
+            'search',
+            stage_user=user,
+            search=search,
+            stage_dest=dest_dir,
+            type='instances-stores',
+            output_format='stage-the-files-json',
+        )
 
     def search_sessions(self, search):
-        return self._do_http_post('search',
-                                  search=search,
-                                  output_format='session-listing-json',
-                                  )
+        return self._do_http_post(
+            'search',
+            search=search,
+            output_format='session-listing-json',
+        )
 
     def search_files(self, search):
-        return self._do_http_post('search',
-                                  search=search,
-                                  output_format='file-listing-json',
-                                  )
+        return self._do_http_post(
+            'search',
+            search=search,
+            output_format='file-listing-json',
+        )
 
     def search_instances(self, search):
-        return self._do_http_post('search',
-                                  search=search,
-                                  output_format='instance-listing-json',
-                                  )
+        return self._do_http_post(
+            'search',
+            search=search,
+            output_format='instance-listing-json',
+        )
 
     def search_observations(self, search):
-        return self._do_http_post('search',
-                                  search=search,
-                                  output_format='obs-listing-json',
-                                  )
+        return self._do_http_post(
+            'search',
+            search=search,
+            output_format='obs-listing-json',
+        )

--- a/hera_librarian/base_store.py
+++ b/hera_librarian/base_store.py
@@ -159,13 +159,13 @@ class BaseStore(object):
             raise RPCError(argv, 'exit code %d; output:\n\n%r' % (proc.returncode, output))
 
     def _globus_transfer(
-            self,
-            local_path,
-            store_path,
-            client_id,
-            transfer_token,
-            source_endpoint_id,
-            destination_endpoint_id,
+        self,
+        local_path,
+        store_path,
+        client_id,
+        transfer_token,
+        source_endpoint_id,
+        destination_endpoint_id,
     ):
         """Copy a file to a particular path using globus.
 
@@ -244,14 +244,14 @@ class BaseStore(object):
     # the server).
 
     def copy_to_store(
-            self,
-            local_path,
-            store_path,
-            try_globus=False,
-            client_id=None,
-            transfer_token=None,
-            source_endpoint_id=None,
-            destination_endpoint_id=None,
+        self,
+        local_path,
+        store_path,
+        try_globus=False,
+        client_id=None,
+        transfer_token=None,
+        source_endpoint_id=None,
+        destination_endpoint_id=None,
     ):
         """Transfer a file to a particular path in the store.
 
@@ -357,8 +357,10 @@ class BaseStore(object):
         else:
             piece = ''
 
-        return self._ssh_slurp("mkdir -p '%s' && chmod u+w '%s' && mv -nT '%s' '%s' && test ! -e '%s'%s" %
-                               (self._path(dest_parent), ssp, ssp, dsp, ssp, piece))
+        return self._ssh_slurp(
+            "mkdir -p '%s' && chmod u+w '%s' && mv -nT '%s' '%s' && test ! -e '%s'%s" %
+            (self._path(dest_parent), ssp, ssp, dsp, ssp, piece)
+        )
 
     def _delete(self, store_path, chmod_before=False):
         """Delete a path from the store.
@@ -403,8 +405,10 @@ class BaseStore(object):
 
         """
         import json
-        text = self._ssh_slurp("python -c \'import hera_librarian.utils as u; u.print_info_for_path(\"%s\")\'"
-                               % (self._path(storepath)))
+        text = self._ssh_slurp(
+            "python -c \'import hera_librarian.utils as u; u.print_info_for_path(\"%s\")\'"
+            % (self._path(storepath))
+        )
         return json.loads(text)
 
     _cached_space_info = None
@@ -469,17 +473,17 @@ class BaseStore(object):
         return 100. * info['used'] / (info['total'])
 
     def upload_file_to_other_librarian(
-            self,
-            conn_name,
-            rec_info,
-            local_store_path,
-            remote_store_path=None,
-            known_staging_store=None,
-            known_staging_subdir=None,
-            use_globus=False,
-            client_id=None,
-            transfer_token=None,
-            source_endpoint_id=None,
+        self,
+        conn_name,
+        rec_info,
+        local_store_path,
+        remote_store_path=None,
+        known_staging_store=None,
+        known_staging_subdir=None,
+        use_globus=False,
+        client_id=None,
+        transfer_token=None,
+        source_endpoint_id=None,
     ):
         """Upload a given file to a different Librarian.
 

--- a/hera_librarian/base_store.py
+++ b/hera_librarian/base_store.py
@@ -236,11 +236,13 @@ class BaseStore(object):
         tc = globus_sdk.TransferClient(authorizer=authorizer)
 
         # make a new data transfer object
+        basename = os.path.basename(os.path.normpath(local_path))
         tdata = globus_sdk.TransferData(
             tc,
             source_endpoint_id,
             destination_endpoint_id,
             sync_level="checksum",
+            label=basename,
             notify_on_succeeded=False,
             notify_on_failed=True,
             notify_on_inactive=True,

--- a/hera_librarian/base_store.py
+++ b/hera_librarian/base_store.py
@@ -24,7 +24,7 @@ from . import RPCError
 NUM_RSYNC_TRIES = 6
 
 
-class BaseStore (object):
+class BaseStore(object):
     """Note that the Librarian server code subclasses this class, so do not change
     its structure without making sure that you're not breaking it.
 
@@ -101,19 +101,24 @@ class BaseStore (object):
         stdin.close()
         return proc
 
-    # Modifications of the store host. These should always be paired with
-    # appropriate modifications of the Librarian server database, either
-    # through an RPC call (if you're a client) or a direct change (if you're
-    # the server).
+    def _rsync_transfer(self, local_path, store_path):
+        """Copy a file to a particular path using rsync.
 
-    def copy_to_store(self, local_path, store_path):
-        """Rsync a file to a particular path in the store.
+        Parameters
+        ----------
+        local_path : str
+            Path to local file to be copied.
+        store_path : str
+            Path to store file at on destination host.
 
-        You should not copy files directly to their intended destinations. You
-        should use the Librarian `prepare_upload` RPC call to get a staging
-        directory and copy your files there; then use the `complete_upload`
-        RPC call to tell the Librarian that you're done.
+        Returns
+        -------
+        None
 
+        Raises
+        ------
+        RPCError
+            Raised if rsync transfer does not complete successfully.
         """
         # Rsync will nest directories in a way that we don't want if we don't
         # end their names with "/", but it will error if we end a file name
@@ -134,8 +139,10 @@ class BaseStore (object):
         argv = [
             'rsync',
             '-aP',
-            '-e', 'ssh -c aes128-ctr -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no',
-            local_path + local_suffix, '%s:%s' % (self.ssh_host, self._path(store_path))
+            '-e',
+            'ssh -c aes128-ctr -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no',
+            local_path + local_suffix,
+            '%s:%s' % (self.ssh_host, self._path(store_path))
         ]
         success = False
 
@@ -150,6 +157,168 @@ class BaseStore (object):
 
         if not success:
             raise RPCError(argv, 'exit code %d; output:\n\n%r' % (proc.returncode, output))
+
+    def _globus_transfer(
+            self,
+            local_path,
+            store_path,
+            client_id,
+            transfer_token,
+            source_endpoint_id,
+            destination_endpoint_id,
+    ):
+        """Copy a file to a particular path using globus.
+
+        For further information on using the Python API for Globus, refer to the
+        Globus SDK docs: https://globus-sdk-python.readthedocs.io/en/stable/
+
+        Parameters
+        ----------
+        local_path : str
+            Path to local file to be copied.
+        store_path : str
+            Path to store file at on destination host.
+        client_id : str
+            The globus client ID to use for the transfer.
+        transfer_token : str
+            The globus transfer token to use for the transfer.
+        source_endpoint_id : str
+            The globus endpoint ID of the source store. May be omitted, in which
+            case we assume it is a "personal" (as opposed to public)
+            client. When using globus, at least one of the source_endpoint_id or
+            destination_endpoint_id must be provided.
+        destination_endpoint_id : str
+            The globus endpoint ID of the destination store. May be omitted, in
+            which case we assume it is a "personal" (as opposed to public)
+            client. When using globus, at least one of the source_endpoint_id or
+            destination_endpoint_id must be provided.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        RPCError
+            Raised if submission of transfer to globus does not complete
+            successfully or if globus_sdk package is not installed.
+        """
+        try:
+            import globus_sdk
+        except ModuleNotFoundError:
+            raise RPCError(
+                "The globus_sdk package must be installed for globus "
+                "functionality. Please `pip install globus_sdk` and try again."
+            )
+
+        # unpack globus information from dict
+        if not isinstance(globus_info, dict):
+            raise RPCError("globus_info must be passed as a dict to use globus")
+        client_id = globus_info["client_id"]
+        transfer_token = globus_info["transfer_token"]
+        source_endpoint_id = globus_info.get("source_endpoint_id", None)
+        destination_endpoint_id = globus_info.get("destination_endpoint_id", None)
+        if source_endpoint_id is None and destination_endpoint_id is None:
+            raise RPCError(
+                "at least one of source_endpoint_id or destination_endpoint_id "
+                "must be specified"
+            )
+        transfer_label = globus_info.get("transfer_label", None)
+
+        # if we're missing endpoint IDs, assume they're a local endpoint
+        if source_endpoint_id is None:
+            local_ep = globus_sdk.LocalGlobusConnectPersonal()
+            source_endpoint_id = local_ep.endpoint_id
+        if destination_endpoint_id is None:
+            local_ep = globus_sdk.LocalGlobusConnectPersonal()
+            destination_endpoint_id = local_ep.endpoint_id
+
+        # make globus transfer client
+        client = globus_sdk.NativeAppAuthClient(client_id)
+        authorizer = globus_sdk.RefreshTokenAuthorizer(transfer_token, client)
+        tc = globus_sdk.TransferClient(authorizer=authorizer)
+
+        # make a new data transfer object
+        tdata = globus_sdk.TransferData(
+            tc,
+            source_endpoint_id,
+            destination_endpoint_id,
+            label=label,
+            sync_level="checksum",
+        )
+
+        # add data to be transferred
+        tdata.add_item(local_path, store_path)
+
+        # initiate transfer
+        transfer_result = tc.submit_transfer(tdata)
+
+        # TODO: figure out appropriate error condition
+        success = "task_id" in transfer_result.keys()
+        if not success:
+            raise RPCError(argv, 'exit code %d; output:\n\n%r' % (proc.returncode, output))
+
+
+    # Modifications of the store host. These should always be paired with
+    # appropriate modifications of the Librarian server database, either
+    # through an RPC call (if you're a client) or a direct change (if you're
+    # the server).
+
+    def copy_to_store(
+            self,
+            local_path,
+            store_path,
+            try_globus=False,
+            client_id=None,
+            transfer_token=None,
+            source_endpoint_id=None,
+            destination_endpoint_id=None,
+    ):
+        """Transfer a file to a particular path in the store.
+
+        You should not copy files directly to their intended destinations. You
+        should use the Librarian `prepare_upload` RPC call to get a staging
+        directory and copy your files there; then use the `complete_upload`
+        RPC call to tell the Librarian that you're done.
+
+        Parameters
+        ----------
+        local_path : str
+            Path to the local file to upload.
+        store_path : str
+            Path to store file at on destination host.
+        try_globus : bool, optional
+            Whether to try to use globus to transfer. If False, or if globus
+            fails, automatically fall back on rsync.
+        client_id : str, optional
+            The globus client ID to use for the transfer.
+        transfer_token : str, optional
+            The globus transfer token to use for the transfer.
+        source_endpoint_id : str, optional
+            The globus endpoint ID of the source store. May be omitted, in which
+            case we assume it is a "personal" (as opposed to public)
+            client. When using globus, at least one of the source_endpoint_id or
+            destination_endpoint_id must be provided.
+        destination_endpoint_id : str, optional
+            The globus endpoint ID of the destination store. May be omitted, in
+            which case we assume it is a "personal" (as opposed to public)
+            client. When using globus, at least one of the source_endpoint_id or
+            destination_endpoint_id must be provided.
+
+        Returns
+        -------
+        None
+        """
+        if try_globus:
+            try:
+                self._globus_transfer(local_path, store_path, globus_info)
+            except RPCError:
+                # something went wrong with globus--fall back on rsync
+                print("Globus transfer failed, falling back on rsync...")
+                self._rsync_transfer(local_path, store_path)
+        else:
+            # use rsync from the get-go
+            self._rsync_transfer(local_path, store_path)
 
     def _chmod(self, store_path, modespec):
         """Change Unix permissions on a path in the store.
@@ -319,19 +488,73 @@ class BaseStore (object):
         info = self.get_space_info()
         return 100. * info['used'] / (info['total'])
 
-    def upload_file_to_other_librarian(self, conn_name, rec_info, local_store_path,
-                                       remote_store_path=None, known_staging_store=None,
-                                       known_staging_subdir=None):
-        """Fire off an rsync process on the store that will upload a given file to a
-        different Librarian. This function will SSH into the store host, from
-        which it will launch an rsync, and it will not return until everything
-        is done! This means that in the real world it may not return for
-        hours, and it will not infrequently raise an exception.
+    def upload_file_to_other_librarian(
+            self,
+            conn_name,
+            rec_info,
+            local_store_path,
+            remote_store_path=None,
+            known_staging_store=None,
+            known_staging_subdir=None,
+            use_globus=False,
+            client_id=None,
+            transfer_token=None,
+            source_endpoint_id=None,
+            destination_endpoint_id=None,
+    ):
+        """Upload a given file to a different Librarian.
 
-        TODO: there is no progress tracking; we just block and eventually
-        return some textual output from the rsync-within-SSH. This is far from
-        ideal.
+        This function will SSH into the store host, from which it will launch an
+        rsync or globus transfer, and it will not return until everything is
+        done! This means that in the real world it may not return for hours, and
+        it will not infrequently raise an exception.
 
+        TODO: there is no internal progress tracking; we just block and
+        eventually return some textual output from the rsync-within-SSH. This is
+        far from ideal. Globus offers some information about transfer progress,
+        but we do not (yet) have automated ways of retrieving it.
+
+        Parameters
+        ----------
+        conn_name : str
+            The name of the external librarian to upload a file to.
+        rec_info : dict
+            A dictionary containing information about the file records being
+            transferred. These are needed by the receiving librarian.
+        local_store_path : str
+            The full path to the file in the local store.
+        remote_store_path : str, optional
+            The full path to the file destination in the remote store. If not
+            specified, it will default to be the same as local_store_path.
+        known_staging_store : str, optional
+            The store corresponding to the already-uploaded file. Must be specified
+            if `known_staging_subdir` is specified.
+        known_staging_subdir : str, optional
+            The target directory corresponding to the already-uploaded file. Must by
+            specified if `known_staging_store` is specified.
+        use_globus : bool, optional
+            Whether to try to use globus to transfer. If False, or if globus
+            fails, automatically fall back on rsync.
+        client_id : str, optional
+            The globus client ID to use for the transfer.
+        transfer_token : str, optional
+            The globus transfer token to use for the transfer.
+        source_endpoint_id : str, optional
+            The globus endpoint ID of the source store. May be omitted, in which
+            case we assume it is a "personal" (as opposed to public)
+            client. When using globus, at least one of the source_endpoint_id or
+            destination_endpoint_id must be provided.
+        destination_endpoint_id : str, optional
+            The globus endpoint ID of the destination store. May be omitted, in
+            which case we assume it is a "personal" (as opposed to public)
+            client. When using globus, at least one of the source_endpoint_id or
+            destination_endpoint_id must be provided.
+
+        Returns
+        -------
+        bytes
+            The output of the `_ssh_slurp` command to log into the store and
+            launch the librarian upload.
         """
         if remote_store_path is None:
             remote_store_path = local_store_path
@@ -349,6 +572,16 @@ class BaseStore (object):
 
         command = 'librarian upload --meta=json-stdin%s %s %s %s' % (
             pre_staged_arg, conn_name, self._path(local_store_path), remote_store_path)
+
+        # optional globus additions to the command
+        if use_globus:
+            command += f" --use_globus --client_id={client_id} --transfer_token={transfer_token}"
+            if source_endpoint_id is not None:
+                command += f" --source_endpoint_id={source_endpoint_id}"
+            if destination_endpoint_id is not None:
+                command += f" --destination_endpoint_id={destination_endpoint_id}"
+
+        # actually run the command
         return self._ssh_slurp(command, input=rec_text)
 
     def upload_file_to_local_store(self, local_store_path, dest_store, dest_rel):

--- a/hera_librarian/cli.py
+++ b/hera_librarian/cli.py
@@ -450,20 +450,73 @@ def config_upload_subparser(sub_parsers):
 
    # add sub parser
    sp = sub_parsers.add_parser("upload", description=doc, epilog=example, help=hlp)
-   sp.add_argument("--meta", dest="meta", default="infer",
-                   help='How to gather metadata: "json-stdin" or "infer"')
-   sp.add_argument("--null-obsid", dest="null_obsid", action="store_true",
-                   help="Require the new file to have *no* obsid associate (for maintenance files)")
-   sp.add_argument("--deletion", dest="deletion", default="disallowed",
-                   help='Whether the created file instance will be deletable: "allowed" or "disallowed"')
-   sp.add_argument("--pre-staged", dest="pre_staged", metavar="STORENAME:SUBDIR",
-                   help="Specify that the data have already been staged at the destination.")
-   sp.add_argument("conn_name", metavar="CONNECTION-NAME",
-                   help=_conn_name_help)
-   sp.add_argument("local_path", metavar="LOCAL-PATH",
-                   help="The path to the data on this machine.")
-   sp.add_argument("dest_store_path", metavar="DEST-PATH",
-                   help='The destination location: combination of "store path" and file name.')
+   sp.add_argument(
+       "--meta",
+       dest="meta",
+       default="infer",
+       help='How to gather metadata: "json-stdin" or "infer"',
+   )
+   sp.add_argument(
+       "--null-obsid",
+       dest="null_obsid",
+       action="store_true",
+       help="Require the new file to have *no* obsid associate (for maintenance files)",
+   )
+   sp.add_argument(
+       "--deletion",
+       dest="deletion",
+       default="disallowed",
+       help=(
+           'Whether the created file instance will be deletable: "allowed" or "disallowed"'
+       ),
+   )
+   sp.add_argument(
+       "--pre-staged",
+       dest="pre_staged",
+       metavar="STORENAME:SUBDIR",
+       help="Specify that the data have already been staged at the destination.",
+   )
+   sp.add_argument(
+       "conn_name", metavar="CONNECTION-NAME", help=_conn_name_help,
+   )
+   sp.add_argument(
+       "local_path", metavar="LOCAL-PATH", help="The path to the data on this machine.",
+   )
+   sp.add_argument(
+       "dest_store_path",
+       metavar="DEST-PATH",
+       help='The destination location: combination of "store path" and file name.',
+   )
+   sp.add_argument(
+       "--use_globus",
+       dest="use_globus",
+       action="store_true",
+       help="Specify that we should try to use globus to transfer data.",
+   )
+   sp.add_argument(
+       "--client_id",
+       dest="client_id",
+       metavar="CLIENT-ID",
+       help="The globus client ID.",
+   )
+   sp.add_argument(
+       "--transfer_token",
+       dest="transfer_token",
+       metavar="TRANSFER-TOKEN",
+       help="The globus transfer token.",
+   )
+   sp.add_argument(
+       "--source_endpoint_id",
+       dest="source_endpoint_id",
+       metavar="SOURCE-ENDPOINT-ID",
+       help="The source endpoint ID for the globus transfer.",
+   )
+   sp.add_argument(
+       "--destination_endpoint_id",
+       dest="destination_endpoint_id",
+       metavar="DESTINATION-ENDPOINT-ID",
+       help="The destination endpoint ID for the globus transfer.",
+   )
    sp.set_defaults(func=upload)
 
    return
@@ -870,9 +923,20 @@ def upload(args):
     client = LibrarianClient(args.conn_name)
 
     try:
-        client.upload_file(args.local_path, args.dest_store_path, meta_mode, rec_info,
-                           deletion_policy=args.deletion, known_staging_store=known_staging_store,
-                           known_staging_subdir=known_staging_subdir, null_obsid=args.null_obsid)
+        client.upload_file(
+            args.local_path,
+            args.dest_store_path,
+            meta_mode,
+            rec_info,
+            deletion_policy=args.deletion,
+            known_staging_store=known_staging_store,
+            known_staging_subdir=known_staging_subdir,
+            null_obsid=args.null_obsid,
+            use_globus=args.use_globus,
+            client_id=args.client_id,
+            source_endpoint_id=args.source_endpoint_id,
+            destination_endpoint_id=args.destination_endpoint_id,
+        )
     except RPCError as e:
         die("upload failed: {}".format(e))
 

--- a/hera_librarian/cli.py
+++ b/hera_librarian/cli.py
@@ -928,6 +928,7 @@ def upload(args):
             null_obsid=args.null_obsid,
             use_globus=args.use_globus,
             client_id=args.client_id,
+            transfer_token=args.transfer_token,
             source_endpoint_id=args.source_endpoint_id,
         )
     except RPCError as e:

--- a/hera_librarian/cli.py
+++ b/hera_librarian/cli.py
@@ -511,12 +511,6 @@ def config_upload_subparser(sub_parsers):
        metavar="SOURCE-ENDPOINT-ID",
        help="The source endpoint ID for the globus transfer.",
    )
-   sp.add_argument(
-       "--destination_endpoint_id",
-       dest="destination_endpoint_id",
-       metavar="DESTINATION-ENDPOINT-ID",
-       help="The destination endpoint ID for the globus transfer.",
-   )
    sp.set_defaults(func=upload)
 
    return
@@ -935,7 +929,6 @@ def upload(args):
             use_globus=args.use_globus,
             client_id=args.client_id,
             source_endpoint_id=args.source_endpoint_id,
-            destination_endpoint_id=args.destination_endpoint_id,
         )
     except RPCError as e:
         die("upload failed: {}".format(e))

--- a/librarian_server/__init__.py
+++ b/librarian_server/__init__.py
@@ -244,6 +244,32 @@ def commandline(argv):
         print('error: unknown server type %r' % server, file=sys.stderr)
         sys.exit(1)
 
+    use_globus = app.config.get("use_globus", False)
+    if use_globus:
+        globus_dict = {}
+        have_all_info = True
+        # make sure we have the other information that we need
+        if "globus_client_id" in app.config.keys():
+            globus_dict["client_id"] = app.config["globus_client_id"]
+        else:
+            print(
+                "error: globus_client_id must be in the config file to use "
+                "globus.",
+                file=sys.stderr,
+            )
+            have_all_info = False
+        if "globus_transfer_token" in app.config.keys():
+            globus_dict["transfer_token"] = app.config["globus_transfer_token"]
+        else:
+            print(
+                "error: globus_transfer_token must be in the config file to use "
+                "globus.",
+                file=sys.stderr,
+            )
+            have_all_info = False
+        if not have_all_info:
+            app.config["use_globus"] = False
+
     bgtasks.maybe_wait_for_threads_to_finish()
 
 

--- a/librarian_server/__init__.py
+++ b/librarian_server/__init__.py
@@ -246,21 +246,16 @@ def commandline(argv):
 
     use_globus = app.config.get("use_globus", False)
     if use_globus:
-        globus_dict = {}
         have_all_info = True
         # make sure we have the other information that we need
-        if "globus_client_id" in app.config.keys():
-            globus_dict["client_id"] = app.config["globus_client_id"]
-        else:
+        if "globus_client_id" not in app.config.keys():
             print(
                 "error: globus_client_id must be in the config file to use "
                 "globus.",
                 file=sys.stderr,
             )
             have_all_info = False
-        if "globus_transfer_token" in app.config.keys():
-            globus_dict["transfer_token"] = app.config["globus_transfer_token"]
-        else:
+        if "globus_transfer_token" not in app.config.keys():
             print(
                 "error: globus_transfer_token must be in the config file to use "
                 "globus.",
@@ -269,6 +264,9 @@ def commandline(argv):
             have_all_info = False
         if not have_all_info:
             app.config["use_globus"] = False
+    else:
+        # add the key just in case it wasn't there
+        app.config["use_globus"] = False
 
     bgtasks.maybe_wait_for_threads_to_finish()
 

--- a/librarian_server/store.py
+++ b/librarian_server/store.py
@@ -442,19 +442,19 @@ class UploaderTask(bgtasks.BackgroundTask):
     t_finish = None
 
     def __init__(
-            self,
-            store,
-            conn_name,
-            rec_info,
-            store_path,
-            remote_store_path,
-            standing_order_name=None,
-            known_staging_store=None,
-            known_staging_subdir=None,
-            use_globus=False,
-            client_id=None,
-            transfer_token=None,
-            source_endpoint_id=None,
+        self,
+        store,
+        conn_name,
+        rec_info,
+        store_path,
+        remote_store_path,
+        standing_order_name=None,
+        known_staging_store=None,
+        known_staging_subdir=None,
+        use_globus=False,
+        client_id=None,
+        transfer_token=None,
+        source_endpoint_id=None,
     ):
         self.store = store
         self.conn_name = conn_name
@@ -546,13 +546,13 @@ class UploaderTask(bgtasks.BackgroundTask):
 
 
 def launch_copy_by_file_name(
-        file_name,
-        connection_name,
-        remote_store_path=None,
-        standing_order_name=None,
-        no_instance='raise',
-        known_staging_store=None,
-        known_staging_subdir=None,
+    file_name,
+    connection_name,
+    remote_store_path=None,
+    standing_order_name=None,
+    no_instance='raise',
+    known_staging_store=None,
+    known_staging_subdir=None,
 ):
     """Launch a copy of a file to a remote Librarian.
 

--- a/librarian_server/store.py
+++ b/librarian_server/store.py
@@ -396,19 +396,53 @@ def register_instances(args, sourcename=None):
 from . import bgtasks
 
 
-class UploaderTask (bgtasks.BackgroundTask):
+class UploaderTask(bgtasks.BackgroundTask):
     """Object that manages the task of copying a file to another Librarian.
 
-    `remote_store_path` may be None, in which case we will request the same
-    "store path" as the file was used in this Librarian by whichever
-    FileInstance we happen to have located.
+    If `known_staging_store` and `known_staging_subdir` are not None, the copy
+    will be launched assuming that files have already been staged at a known
+    location at the final destination. This is useful if files have been
+    copied from one Librarian site to another outside of the Librarian
+    framework.
 
+    Parameters
+    ----------
+    store : BaseStore object
+        A BaseStore object corresponding to the originating store.
+    conn_name : str
+        The name of the connection to use, as defined in ~/.hl_client.cfg.
+    rec_info : dict
+        A dictionary containing database information for the file to be
+        transferred.
+    store_path : str
+        The full path to the file in the local store.
+    remote_store_path : str, optional
+        The path to place the file in the destination store. This may be None,
+        in which case we will request the same "store path" as the FileInstance
+        in this Librarian.
+    standing_order_name : str, optional
+        The standing order corresponding to this upload task.
+    known_staging_store : str, optional
+        The store corresponding to the already-uploaded file. Must be specified
+        if `known_staging_subdir` is specified.
+    known_staging_subdir : str, optional
+        The target directory corresponding to the already-uploaded file. Must by
+        specified if `known_staging_store` is specified.
     """
     t_start = None
     t_finish = None
 
-    def __init__(self, store, conn_name, rec_info, store_path, remote_store_path, standing_order_name=None,
-                 known_staging_store=None, known_staging_subdir=None):
+    def __init__(
+            self,
+            store,
+            conn_name,
+            rec_info,
+            store_path,
+            remote_store_path,
+            standing_order_name=None,
+            known_staging_store=None,
+            known_staging_subdir=None,
+    ):
         self.store = store
         self.conn_name = conn_name
         self.rec_info = rec_info
@@ -428,10 +462,15 @@ class UploaderTask (bgtasks.BackgroundTask):
         import time
         self.t_start = time.time()
         self.store.upload_file_to_other_librarian(
-            self.conn_name, self.rec_info,
-            self.store_path, self.remote_store_path,
+            self.conn_name,
+            self.rec_info,
+            self.store_path,
+            self.remote_store_path,
             known_staging_store=self.known_staging_store,
-            known_staging_subdir=self.known_staging_subdir)
+            known_staging_subdir=self.known_staging_subdir,
+            use_globus=use_globus,
+            globus_dict=globus_dict,
+        )
         self.t_finish = time.time()
 
     def wrapup_function(self, retval, exc):
@@ -487,9 +526,15 @@ class UploaderTask (bgtasks.BackgroundTask):
             raise ServerError('failed to commit completion events to database')
 
 
-def launch_copy_by_file_name(file_name, connection_name, remote_store_path=None,
-                             standing_order_name=None, no_instance='raise',
-                             known_staging_store=None, known_staging_subdir=None):
+def launch_copy_by_file_name(
+        file_name,
+        connection_name,
+        remote_store_path=None,
+        standing_order_name=None,
+        no_instance='raise',
+        known_staging_store=None,
+        known_staging_subdir=None,
+):
     """Launch a copy of a file to a remote Librarian.
 
     A ServerError will be raised if no instance of the file is available.
@@ -534,16 +579,21 @@ def launch_copy_by_file_name(file_name, connection_name, remote_store_path=None,
 
     # Launch the background task. We need to convert the Store to a base object since
     # the background task can't access the database.
-
     basestore = inst.store_object.convert_to_base_object()
-    bgtasks.submit_background_task(UploaderTask(
-        basestore, connection_name, rec_info, inst.store_path,
-        remote_store_path, standing_order_name,
-        known_staging_store=known_staging_store,
-        known_staging_subdir=known_staging_subdir))
+    bgtasks.submit_background_task(
+        UploaderTask(
+            basestore,
+            connection_name,
+            rec_info,
+            inst.store_path,
+            remote_store_path,
+            standing_order_name,
+            known_staging_store=known_staging_store,
+            known_staging_subdir=known_staging_subdir,
+        )
+    )
 
     # Remember that we launched this copy.
-
     db.session.add(file.make_copy_launched_event(connection_name, remote_store_path))
 
     try:

--- a/librarian_server/store.py
+++ b/librarian_server/store.py
@@ -631,10 +631,15 @@ def launch_copy_by_file_name(
 
     # Figure out if we should try to use globus or not
     if app.config["use_globus"]:
-        use_globus = True
-        client_id = app.config["globus_client_id"]
-        transfer_token = app.config["globus_transfer_token"]
-        source_endpoint_id = app.config["globus_endpoint_id"]
+        source_endpoint_id = app.config.get("globus_endpoint_id", None)
+        try:
+            client_id = app.config["globus_client_id"]
+            transfer_token = app.config["globus_transfer_token"]
+            use_globus = True
+        except KeyError:
+            client_id = None
+            transfer_token = None
+            use_globus = False
     else:
         use_globus = False
         client_id = None

--- a/librarian_server/webutil.py
+++ b/librarian_server/webutil.py
@@ -27,7 +27,7 @@ from . import app, logger
 
 # Generic authentication stuff
 
-class AuthFailedError (Exception):
+class AuthFailedError(Exception):
     pass
 
 
@@ -54,7 +54,7 @@ def _check_authentication(auth):
 
 # The RPC (Remote Procedure Call) interface
 
-class ServerErrorBase (Exception):
+class ServerErrorBase(Exception):
     def __init__(self, status, fmt, args):
         self.status = status
 
@@ -67,7 +67,7 @@ class ServerErrorBase (Exception):
         return self.message
 
 
-class ServerError (ServerErrorBase):
+class ServerError(ServerErrorBase):
     """Raise this when an error is encountered in an API call. An error message
     will be returned, and the HTTP request will return error 400, which is
     usually what you want.

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ packages = find_packages(exclude=["*.tests"])
 
 setup(
     name=package_name,
-    version="1.0.1",
+    version="1.1.0",
     author="HERA Team",
     author_email="hera@lists.berkeley.edu",
     url="https://github.com/HERA-Team/librarian/",


### PR DESCRIPTION
This PR adds the ability to use globus to transfer files. If the globus transfer fails for any reason, the librarian falls back on `rsync`. We also add documentation explaining how to install and configure globus both on-site and at the target destination (e.g., NRAO, NERSC, etc.). This PR also include some formatting changes that hopefully increase readability.