### PR TITLE
Fix handling of directories in globus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Version *next* (not yet released)
-
+- Fix handling of directories in Globus.
 
 
 # Version 1.1.0 (2020 Feb 7)

--- a/hera_librarian/base_store.py
+++ b/hera_librarian/base_store.py
@@ -258,7 +258,11 @@ class BaseStore(object):
                     store_path = store_path.lstrip("/")
 
         # add data to be transferred
-        tdata.add_item(local_path, store_path)
+        if os.path.isdir(local_path):
+            recursive = True
+        else:
+            recursive = False
+        tdata.add_item(local_path, store_path, recursive=recursive)
 
         # initiate transfer
         transfer_result = tc.submit_transfer(tdata)


### PR DESCRIPTION
When transferring directories using Globus, the `recursive` flag of the `add_data` method must be set to `True`, or the transfer errors. However, for files, this flag must be `False`. This PR ensures the flag is set properly.