### PR TITLE
SQLAlchemy update

### DIFF
--- a/librarian_server/file.py
+++ b/librarian_server/file.py
@@ -18,6 +18,7 @@ import json
 import os.path
 import re
 from flask import flash, redirect, render_template, url_for
+from sqlalchemy.engine.row import Row
 
 from . import app, db, logger
 from .dbutil import NotNull, SQLAlchemyError
@@ -216,6 +217,9 @@ class File (db.Model):
                 # Librarians.
                 MC.create_observation_record(obsid)
 
+        if isinstance(obsid, Row):
+            # convert from Row object to integer
+            obsid = obsid._asdict()["obsid"]
         fobj = File(name, type, obsid, source_name, size, md5)
 
         if MC.is_file_record_invalid(fobj):

--- a/librarian_server/mc_integration.py
+++ b/librarian_server/mc_integration.py
@@ -26,6 +26,7 @@ import time
 from astropy.time import Time
 import six
 from sqlalchemy.exc import InvalidRequestError
+from sqlalchemy.engine.row import Row
 
 from . import app, db, is_primary_server, logger
 from .dbutil import SQLAlchemyError
@@ -199,7 +200,12 @@ class MCManager(object):
         if file_obj.obsid is None:
             return False  # this is OK, for maintenance files
 
-        for mc_obs in self.mc_session.get_obs(obsid=file_obj.obsid):
+        if isinstance(file_obj.obsid, Row):
+            # convert from Row object to int
+            obsid = file_obj.obsid._asdict()["obsid"]
+        else:
+            obsid = file_obj.obsid
+        for mc_obs in self.mc_session.get_obs(obsid=obsid):
             return False  # if this executes, we got one and the file's OK
 
         # If we got here, there was no session and something bad is up!

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ although those modules are not installed in a standard ``pip install``.
             "psycopg2",  # FIXME: only of using Postgres
             "pytz",
             "pyuvdata",
-            "sqlalchemy",
+            "sqlalchemy>=1.4.0",
         ]
     },
     scripts=[


### PR DESCRIPTION
Evidently there was a recent-ish change in SQLAlchemy where there was stricter handling of `Row` objects (detailed [a bit in the documentation of the object](https://docs.sqlalchemy.org/en/14/core/connections.html#sqlalchemy.engine.Row)), and how we were handling some of the entries led to downstream errors in the Postgres ORM. These changes work empirically for v1.4.22, though they might not work for previous (<1.4) versions. As such, we have added a version requirement to the package.