### PR TITLE
add-obs with null-obsid

### DIFF
--- a/hera_librarian/__init__.py
+++ b/hera_librarian/__init__.py
@@ -340,11 +340,12 @@ class LibrarianClient(object):
             null_obsid=null_obsid,
         )
 
-    def register_instances(self, store_name, file_info):
+    def register_instances(self, store_name, file_info, null_obsid):
         return self._do_http_post(
             'register_instances',
             store_name=store_name,
             file_info=file_info,
+            null_obsid=null_obsid,
         )
 
     def locate_file_instance(self, file_name):

--- a/hera_librarian/cli.py
+++ b/hera_librarian/cli.py
@@ -214,11 +214,8 @@ def config_add_obs_subparser(sub_parsers):
                     help="The 'store' name under which the Librarian knows this computer.")
     sp.add_argument("paths", metavar="PATHS", nargs="+",
                     help="The paths to the files on this computer.")
-    sp.add_argument(
-        "--null-obsid",
-        dest="null_obsid",
-        action="store_true",
-        help="Require the new file to have *no* obsid associate (for maintenance files)",
+    sp.add_argument("--null-obsid", dest="null_obsid", action="store_true",
+                    help="Require the new file to have *no* obsid associated (for maintenance files)",
     )
     sp.set_defaults(func=add_obs)
 
@@ -480,7 +477,7 @@ def config_upload_subparser(sub_parsers):
        "--null-obsid",
        dest="null_obsid",
        action="store_true",
-       help="Require the new file to have *no* obsid associate (for maintenance files)",
+       help="Require the new file to have *no* obsid associated (for maintenance files)",
    )
    sp.add_argument(
        "--deletion",

--- a/hera_librarian/cli.py
+++ b/hera_librarian/cli.py
@@ -208,12 +208,18 @@ def config_add_obs_subparser(sub_parsers):
 
     # add sub parser
     sp = sub_parsers.add_parser("add-obs", description=doc, help=hlp)
-    sp.add_argument("connection_name", metavar="CONNECTION-NAME", type=str,
+    sp.add_argument("conn_name", metavar="CONNECTION-NAME", type=str,
                     help=_conn_name_help)
     sp.add_argument("store_name", metavar="NAME",
                     help="The 'store' name under which the Librarian knows this computer.")
     sp.add_argument("paths", metavar="PATHS", nargs="+",
                     help="The paths to the files on this computer.")
+    sp.add_argument(
+        "--null-obsid",
+        dest="null_obsid",
+        action="store_true",
+        help="Require the new file to have *no* obsid associate (for maintenance files)",
+    )
     sp.set_defaults(func=add_obs)
 
     return
@@ -580,8 +586,8 @@ def add_obs(args):
     print("Registering with Librarian.")
     client = LibrarianClient(args.conn_name)
     try:
-        client.register_instances(args.store_name, file_info)
-    except RCPError as e:
+        client.register_instances(args.store_name, file_info, null_obsid=args.null_obsid)
+    except RPCError as e:
         die("RPC failed: {}".format(e))
 
     return

--- a/librarian_server/store.py
+++ b/librarian_server/store.py
@@ -378,7 +378,7 @@ def register_instances(args, sourcename=None):
     """
     store_name = required_arg(args, str, 'store_name')
     file_info = required_arg(args, dict, 'file_info')
-    null_obsid = required_arg(args, bool, 'null_obsid')
+    null_obsid = optional_arg(args, bool, 'null_obsid', False)
 
     from .file import File, FileInstance
 

--- a/librarian_server/store.py
+++ b/librarian_server/store.py
@@ -378,6 +378,7 @@ def register_instances(args, sourcename=None):
     """
     store_name = required_arg(args, str, 'store_name')
     file_info = required_arg(args, dict, 'file_info')
+    null_obsid = required_arg(args, bool, 'null_obsid')
 
     from .file import File, FileInstance
 
@@ -404,7 +405,7 @@ def register_instances(args, sourcename=None):
         # OK, we have to create some stuff.
 
         file = File.get_inferring_info(store, store_path, sourcename,
-                                       info=file_info[full_path])
+                                       info=file_info[full_path], null_obsid=null_obsid)
         inst = FileInstance(store, parent_dirs, name)
         db.session.add(inst)
         db.session.add(file.make_instance_creation_event(inst, store))

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ although those modules are not installed in a standard ``pip install``.
             "flask-sqlalchemy",
             "hera-librarian",
             "numpy",
-            "psycopg2",  # FIXME: only of using Postgres
+            "psycopg2-binary",
             "pytz",
             "pyuvdata",
             "sqlalchemy>=1.4.0",


### PR DESCRIPTION
I was playing with the librarian and had a specific need to add observations on the server with the librarian for prototyping. While doing that, I found a few bugs in the `add-obs` code. I also added a way to pass a `null-obsid` argument to the add-obs CLI.
I made a small change to the setup.py that helped me avoid a dependency issue. I can remove that, if you prefer.