### PR TITLE
Add testing against current versions of python, fix known issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,3 +62,18 @@ workflows:
       - librarian:
           name: librarian_3.8
           python_version: "3.8"
+      - librarian:
+          name: librarian_3.9
+          python_version: "3.9"
+      - librarian:
+          name: librarian_3.10
+          python_version: "3.10"
+      - librarian:
+          name: librarian_3.11
+          python_version: "3.11"
+      - librarian:
+          name: librarian_3.12
+          python_version: "3.12"
+      - librarian:
+          name: librarian_3.13
+          python_version: "3.13"

--- a/hera_librarian/__init__.py
+++ b/hera_librarian/__init__.py
@@ -2,8 +2,8 @@
 # Copyright 2016 the HERA Team.
 # Licensed under the BSD License.
 
-
-from pkg_resources import DistributionNotFound, get_distribution
+import contextlib
+from importlib.metadata import version, PackageNotFoundError
 
 import json
 import os.path
@@ -22,11 +22,9 @@ LibrarianClient
 ).split()
 
 
-try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    # package is not installed
-    pass
+# do not set version if package is not installed
+with contextlib.suppress(PackageNotFoundError):
+    __version__ = version("hera_librarian")
 
 
 class NoSuchConnectionError(Exception):

--- a/librarian_server/__init__.py
+++ b/librarian_server/__init__.py
@@ -8,15 +8,18 @@ probably ways to work around that but things work well enough as is.
 """
 
 
-from pkg_resources import DistributionNotFound, get_distribution, parse_version
+from importlib.metadata import version, PackageNotFoundError
+from packaging.version import parse
 
 import contextlib
 import logging
 import sys
 
-with contextlib.suppress(DistributionNotFound):
+
+with contextlib.suppress(PackageNotFoundError):
     # version information is saved under hera_librarian package
-    __version__ = get_distribution("hera_librarian").version
+    __version__ = version("hera_librarian")
+
 _log_level_names = {
     "debug": logging.DEBUG,
     "info": logging.INFO,
@@ -119,7 +122,7 @@ def get_version_info():
     git_hash : str
         The git hash of the installed librarian server.
     """
-    parsed_version = parse_version(__version__)
+    parsed_version = parse(__version__)
     tag = parsed_version.base_version
     local = parsed_version.local
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ all_reqs = server_reqs + globus_reqs
 
 setup(
     name=package_name,
-    version="1.1.1",
     author="HERA Team",
     author_email="hera@lists.berkeley.edu",
     url="https://github.com/HERA-Team/librarian/",


### PR DESCRIPTION
This fixes issues with running on more modern versions of python. It also adds testing against them so we can know if they work.

There's some contradictory stuff in the repo about versioning that I'd like to sort out before we merge this. There's code and code comments related to versioning using setuptools_scm, but the version is hardcoded to "1.1.1" in setup.py.