### PR TITLE
Switch to psycopg3 for numpy 2.0 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,3 +62,18 @@ workflows:
       - librarian:
           name: librarian_3.8
           python_version: "3.8"
+      - librarian:
+          name: librarian_3.9
+          python_version: "3.9"
+      - librarian:
+          name: librarian_3.10
+          python_version: "3.10"
+      - librarian:
+          name: librarian_3.11
+          python_version: "3.11"
+      - librarian:
+          name: librarian_3.12
+          python_version: "3.12"
+      - librarian:
+          name: librarian_3.13
+          python_version: "3.13"

--- a/ci/librarian_server_conda_env.yml
+++ b/ci/librarian_server_conda_env.yml
@@ -10,8 +10,8 @@ dependencies:
   - flask-sqlalchemy
   - jinja2
   - numpy
-  - psycopg2
+  - psycopg>=3.2.2
   - pytz
   - pyuvdata
-  - sqlalchemy
+  - sqlalchemy>=2.0
   - tornado

--- a/ci/librarian_tests.yml
+++ b/ci/librarian_tests.yml
@@ -10,9 +10,9 @@ dependencies:
   - h5py
   - jinja2
   - numpy
-  - psycopg2
+  - psycopg>=3.2.2
   - pytest
   - pytz
   - pyuvdata
-  - sqlalchemy
+  - sqlalchemy>=2.0
   - tornado

--- a/ci/server-config-ci.json
+++ b/ci/server-config-ci.json
@@ -3,7 +3,7 @@
 
     "SECRET_KEY": "d41d8cd98f00b204e9800998ecf8427e",
 
-    "SQLALCHEMY_DATABASE_URI": "postgresql://localhost/librarian_test",
+    "SQLALCHEMY_DATABASE_URI": "postgresql+psycopg://localhost/librarian_test",
 
     "SQLALCHEMY_TRACK_MODIFICATIONS": false,
 

--- a/container/server-config-docker.json
+++ b/container/server-config-docker.json
@@ -3,7 +3,7 @@
 
     "SECRET_KEY": "d41d8cd98f00b204e9800998ecf8427e",
 
-    "SQLALCHEMY_DATABASE_URI": "postgresql://postgres:password@db/librarian",
+    "SQLALCHEMY_DATABASE_URI": "postgresql+psycopg://postgres:password@db/librarian",
 
     "SQLALCHEMY_TRACK_MODIFICATIONS": false,
 

--- a/hera_librarian/__init__.py
+++ b/hera_librarian/__init__.py
@@ -2,8 +2,8 @@
 # Copyright 2016 the HERA Team.
 # Licensed under the BSD License.
 
-
-from pkg_resources import DistributionNotFound, get_distribution
+import contextlib
+from importlib.metadata import version, PackageNotFoundError
 
 import json
 import os.path
@@ -22,11 +22,9 @@ LibrarianClient
 ).split()
 
 
-try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    # package is not installed
-    pass
+# do not set version if package is not installed
+with contextlib.suppress(PackageNotFoundError):
+    __version__ = version("hera_librarian")
 
 
 class NoSuchConnectionError(Exception):

--- a/librarian_server/__init__.py
+++ b/librarian_server/__init__.py
@@ -8,15 +8,18 @@ probably ways to work around that but things work well enough as is.
 """
 
 
-from pkg_resources import DistributionNotFound, get_distribution, parse_version
+from importlib.metadata import version, PackageNotFoundError
+from packaging.version import parse
 
 import contextlib
 import logging
 import sys
 
-with contextlib.suppress(DistributionNotFound):
+
+with contextlib.suppress(PackageNotFoundError):
     # version information is saved under hera_librarian package
-    __version__ = get_distribution("hera_librarian").version
+    __version__ = version("hera_librarian")
+
 _log_level_names = {
     "debug": logging.DEBUG,
     "info": logging.INFO,
@@ -119,7 +122,7 @@ def get_version_info():
     git_hash : str
         The git hash of the installed librarian server.
     """
-    parsed_version = parse_version(__version__)
+    parsed_version = parse(__version__)
     tag = parsed_version.base_version
     local = parsed_version.local
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ all_reqs = server_reqs + globus_reqs
 
 setup(
     name=package_name,
-    version="1.1.1",
     author="HERA Team",
     author_email="hera@lists.berkeley.edu",
     url="https://github.com/HERA-Team/librarian/",

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,10 @@ server_reqs = [
     "flask_sqlalchemy",
     "hera-librarian",
     "numpy",
-    "psycopg2-binary",
+    "psycopg>=3.2.2",
     "pytz",
     "pyuvdata",
-    "sqlalchemy>=1.4.0",
+    "sqlalchemy>=2.0",
     "tornado",
 ]
 


### PR DESCRIPTION
Things are broken onsite. We need to be able to use psycopg3.